### PR TITLE
세벌식 3-2014 이름 변경

### DIFF
--- a/OSX/GureumComposer.h
+++ b/OSX/GureumComposer.h
@@ -28,6 +28,7 @@ FOUNDATION_EXTERN NSString *kGureumInputSourceIdentifierHan3_2011;
 FOUNDATION_EXTERN NSString *kGureumInputSourceIdentifierHan3_2011Loose;
 FOUNDATION_EXTERN NSString *kGureumInputSourceIdentifierHan3_2012;
 FOUNDATION_EXTERN NSString *kGureumInputSourceIdentifierHan3_2012Loose;
+FOUNDATION_EXTERN NSString *kGureumInputSourceIdentifierHan3_2014;
 
 @class HangulComposer;
 @class HanjaComposer;

--- a/OSX/GureumComposer.m
+++ b/OSX/GureumComposer.m
@@ -35,6 +35,7 @@ NSString *kGureumInputSourceIdentifierHan3_2011Loose = @"org.youknowone.inputmet
 NSString *kGureumInputSourceIdentifierHan3_2012 = @"org.youknowone.inputmethod.Gureum.han3-2012";
 NSString *kGureumInputSourceIdentifierHan3_2012Loose = @"org.youknowone.inputmethod.Gureum.han3-2012loose";
 NSString *kGureumInputSourceIdentifierHan3FinalNoShift = @"org.youknowone.inputmethod.Gureum.han3finalnoshift";
+NSString *kGureumInputSourceIdentifierHan3_2014 = @"org.youknowone.inputmethod.Gureum.han3-2014";
 
 #import "HangulComposer.h"
 
@@ -82,6 +83,7 @@ NSDictionary *GureumInputSourceToHangulKeyboardIdentifierTable = nil;
                                                         @"3-2012", kGureumInputSourceIdentifierHan3_2012,
                                                         @"3-2012l", kGureumInputSourceIdentifierHan3_2012Loose,
                                                         @"3fs", kGureumInputSourceIdentifierHan3FinalNoShift,
+                                                        @"3-2014", kGureumInputSourceIdentifierHan3_2014,
                                                         nil];
 }
 

--- a/OSX/GureumPreferencesWindowController.m
+++ b/OSX/GureumPreferencesWindowController.m
@@ -55,6 +55,7 @@ static NSArray *GureumPreferencesHangulSyllablePresentations = nil;
                      @"org.youknowone.inputmethod.Gureum.han3-2012",
                      @"org.youknowone.inputmethod.Gureum.han3-2012loose",
                      @"org.youknowone.inputmethod.Gureum.han3finalnoshift",
+                     @"org.youknowone.inputmethod.Gureum.han3-2014",
                      nil];
 
     NSDictionary *info = [[NSBundle mainBundle] localizedInfoDictionary];

--- a/OSX/Info.plist
+++ b/OSX/Info.plist
@@ -152,6 +152,27 @@
 				<key>tsInputModeScriptKey</key>
 				<string>smKorean</string>
 			</dict>
+			<key>org.youknowone.inputmethod.Gureum.han3-2014</key>
+			<dict>
+				<key>TISInputSourceID</key>
+				<string>org.youknowone.inputmethod.Gureum.han3-2014</string>
+				<key>TISIntendedLanguage</key>
+				<string>ko</string>
+				<key>tsInputModeAlternateMenuIconFileKey</key>
+				<string>han3.png</string>
+				<key>tsInputModeDefaultStateKey</key>
+				<false/>
+				<key>tsInputModeIsVisibleKey</key>
+				<true/>
+				<key>tsInputModeMenuIconFileKey</key>
+				<string>han3.png</string>
+				<key>tsInputModePaletteIconFileKey</key>
+				<string>han3.png</string>
+				<key>tsInputModePrimaryInScriptKey</key>
+				<false/>
+				<key>tsInputModeScriptKey</key>
+				<string>smKorean</string>
+			</dict>
 			<key>org.youknowone.inputmethod.Gureum.han390</key>
 			<dict>
 				<key>TISInputSourceID</key>
@@ -402,6 +423,7 @@
 			<string>org.youknowone.inputmethod.Gureum.han3-2012loose</string>
 			<string>org.youknowone.inputmethod.Gureum.han3finalnoshift</string>
 			<string>org.youknowone.inputmethod.Gureum.hanahnmatae</string>
+			<string>org.youknowone.inputmethod.Gureum.han3-2014</string>
 		</array>
 	</dict>
 	<key>HIMHanjaWindowSettings</key>

--- a/OSX/en.lproj/InfoPlist.strings
+++ b/OSX/en.lproj/InfoPlist.strings
@@ -19,6 +19,7 @@ org.youknowone.inputmethod.Gureum.han3-2011loose = "Han 3set 2011 (Loose Combina
 org.youknowone.inputmethod.Gureum.han3-2012 = "Han 3set 2012";
 org.youknowone.inputmethod.Gureum.han3-2012loose = "Han 3set 2012 (Loose Combination)";
 org.youknowone.inputmethod.Gureum.han3finalnoshift = "Han 3set Final No shift (Compatible)";
+org.youknowone.inputmethod.Gureum.han3-2014 = "Han 3set Gathering 2014";
 
 CFBundleName = "Gureum";
 CFBundleDisplayName = "Gureum Input Method";

--- a/OSX/ko.lproj/InfoPlist.strings
+++ b/OSX/ko.lproj/InfoPlist.strings
@@ -19,6 +19,7 @@ org.youknowone.inputmethod.Gureum.han3-2011loose = "세벌식 2011 (종성결합
 org.youknowone.inputmethod.Gureum.han3-2012 = "세벌식 2012";
 org.youknowone.inputmethod.Gureum.han3-2012loose = "세벌식 2012 (종성결합허용)";
 org.youknowone.inputmethod.Gureum.han3finalnoshift = "세벌식 최종 순아래 (호환)";
+org.youknowone.inputmethod.Gureum.han3-2014 = "세벌식 모아치기 2014";
 
 CFBundleName = "구름";
 CFBundleDisplayName = "구름 입력기";


### PR DESCRIPTION
번거롭게 해 드려서 죄송합니다... '세벌식 사랑 모임' 카페에서 이 자판에 대해 토론을 한 결과, 이 자판의 이름을 바꾸게 되었습니다. '세벌식 3-2014 통합' 에서 '세벌식 모아치기 2014'로 바꾸게 되어 풀 리퀘스트를 드리게 되었습니다... 그리고 커밋을 합치는 방법을 몰라서 못 합쳤습니다. 혹시라도 방법을 알려주신다면 커밋을 합쳐 드리겠습니다,,,
