### PR TITLE
Fix references for 3-2011, 3-2012 keyboard

### DIFF
--- a/Gureum.xcodeproj/project.pbxproj
+++ b/Gureum.xcodeproj/project.pbxproj
@@ -87,6 +87,9 @@
 		38F85969215BF4BA00CD80AE /* Preferences.prefPane in Resources */ = {isa = PBXBuildFile; fileRef = 382E68641A1314D900031D1D /* Preferences.prefPane */; };
 		38FA21DD14230E2E00444D67 /* CIMInputController.m in Sources */ = {isa = PBXBuildFile; fileRef = 38863C96140E669000A8ED76 /* CIMInputController.m */; };
 		5BFD1CC577B7F0E1650E54BA /* Pods_Preferences.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44C08D5450D78FCDA4226ECE /* Pods_Preferences.framework */; };
+		80383E6D2161F0D300FC5FB6 /* hangul-keyboard-3-2012.xml in Copy Keyboards Files */ = {isa = PBXBuildFile; fileRef = 80383E6A2161F0D300FC5FB6 /* hangul-keyboard-3-2012.xml */; };
+		80383E6E2161F0D300FC5FB6 /* hangul-keyboard-3-2011.xml in Copy Keyboards Files */ = {isa = PBXBuildFile; fileRef = 80383E6B2161F0D300FC5FB6 /* hangul-keyboard-3-2011.xml */; };
+		80383E6F2161F0D300FC5FB6 /* hangul-combination-3p.xml in Copy Keyboards Files */ = {isa = PBXBuildFile; fileRef = 80383E6C2161F0D300FC5FB6 /* hangul-combination-3p.xml */; };
 		878898012160AA6E00BF5770 /* CIMInputManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871B807B2153DDFA0013EE69 /* CIMInputManager.swift */; };
 		8FB2D1F50746B5A15A5617BE /* libPods-OSXTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E73EDD6DBCA6CA17A1708BE5 /* libPods-OSXTests.a */; };
 		A3BAAE0C2160C6FC0076C66D /* GureumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BAAE062160C6970076C66D /* GureumTests.swift */; };
@@ -191,6 +194,9 @@
 			dstPath = keyboards;
 			dstSubfolderSpec = 7;
 			files = (
+				80383E6D2161F0D300FC5FB6 /* hangul-keyboard-3-2012.xml in Copy Keyboards Files */,
+				80383E6E2161F0D300FC5FB6 /* hangul-keyboard-3-2011.xml in Copy Keyboards Files */,
+				80383E6F2161F0D300FC5FB6 /* hangul-combination-3p.xml in Copy Keyboards Files */,
 				3835B5421F5DAC4400896BEC /* hangul-combination-3f.xml in Copy Keyboards Files */,
 				3835B5431F5DAC4400896BEC /* hangul-combination-39.xml in Copy Keyboards Files */,
 				3835B5441F5DAC4400896BEC /* hangul-combination-default.xml in Copy Keyboards Files */,
@@ -326,6 +332,9 @@
 		4F10FF4A81E4501FB2F71251 /* Pods_PreferencesApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PreferencesApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F1238C7C58357731B8AE5B9 /* Pods-OSXTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OSXTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-OSXTests/Pods-OSXTests.release.xcconfig"; sourceTree = "<group>"; };
 		60EF36B9B3B06EE1D160329E /* Pods-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OSX.release.xcconfig"; path = "Pods/Target Support Files/Pods-OSX/Pods-OSX.release.xcconfig"; sourceTree = "<group>"; };
+		80383E6A2161F0D300FC5FB6 /* hangul-keyboard-3-2012.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "hangul-keyboard-3-2012.xml"; sourceTree = "<group>"; };
+		80383E6B2161F0D300FC5FB6 /* hangul-keyboard-3-2011.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "hangul-keyboard-3-2011.xml"; sourceTree = "<group>"; };
+		80383E6C2161F0D300FC5FB6 /* hangul-combination-3p.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "hangul-combination-3p.xml"; sourceTree = "<group>"; };
 		871B807B2153DDFA0013EE69 /* CIMInputManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CIMInputManager.swift; sourceTree = "<group>"; };
 		8837333857ED65F9D5DAD88B /* Pods-PreferencesApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PreferencesApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-PreferencesApp/Pods-PreferencesApp.release.xcconfig"; sourceTree = "<group>"; };
 		8DDF3209586DA50868B852BE /* Pods-Preferences.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Preferences.release.xcconfig"; path = "Pods/Target Support Files/Pods-Preferences/Pods-Preferences.release.xcconfig"; sourceTree = "<group>"; };
@@ -469,11 +478,14 @@
 				3835B4F51F5DAA7100896BEC /* hangul-combination-3gc.xml */,
 				3835B4F61F5DAA7100896BEC /* hangul-combination-3gs.xml */,
 				3835B53E1F5DAC3500896BEC /* hangul-combination-3f.xml */,
+				80383E6C2161F0D300FC5FB6 /* hangul-combination-3p.xml */,
 				3835B53F1F5DAC3500896BEC /* hangul-combination-39.xml */,
 				3835B5401F5DAC3500896BEC /* hangul-combination-default.xml */,
 				3835B5411F5DAC3500896BEC /* hangul-combination-full.xml */,
 				3835B4F71F5DAA7100896BEC /* hangul-keyboard-2.xml */,
 				3835B4F81F5DAA7100896BEC /* hangul-keyboard-2y.xml */,
+				80383E6B2161F0D300FC5FB6 /* hangul-keyboard-3-2011.xml */,
+				80383E6A2161F0D300FC5FB6 /* hangul-keyboard-3-2012.xml */,
 				3835B4F91F5DAA7100896BEC /* hangul-keyboard-32.xml */,
 				3835B4FA1F5DAA7100896BEC /* hangul-keyboard-39.xml */,
 				3835B4FB1F5DAA7100896BEC /* hangul-keyboard-39s.xml */,


### PR DESCRIPTION
Gureum의 Build Phases > Copy Keyboard Files에서 빠진 파일을 추가했습니다.

추가로 현재 master 브랜치에서 빌드하면 종성 입력을 위해 Shift를 누르는 순간 조합이 중단되는 현상이 발생합니다.