### PR TITLE
Fix about panel

### DIFF
--- a/CommonInputMethod/CIMInputController.h
+++ b/CommonInputMethod/CIMInputController.h
@@ -60,12 +60,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface CIMInputController (CIMMenu)
-
-- (IBAction)showStandardAboutPanel:(id)sender;
-
-@end
-
 
 #if DEBUG
 

--- a/CommonInputMethod/CIMInputController.m
+++ b/CommonInputMethod/CIMInputController.m
@@ -456,14 +456,6 @@ TISInputSource *_USSource() {
 
 @end
 
-@implementation CIMInputController (CIMMenu)
-
-- (void)showStandardAboutPanel:(id)sender {
-    [NSApp orderFrontStandardAboutPanel:sender];
-}
-
-@end
-
 
 #if DEBUG
 

--- a/CommonInputMethod/CIMInputController.swift
+++ b/CommonInputMethod/CIMInputController.swift
@@ -8,6 +8,12 @@
 
 import Foundation
 
+extension CIMInputController {
+    @IBAction func showStandardAboutPanel(_ sender: Any) {
+        NSApp.orderFrontStandardAboutPanel(sender)
+    }
+}
+
 @objcMembers class CIMMockInputController: CIMInputController {
     @objc var _receiver: CIMInputReceiver
     
@@ -60,6 +66,4 @@ extension CIMMockInputController {
         self._receiver.commitCompositionEvent(sender, controller: self)
         // COMMIT triggered
     }
-    
-    
 }

--- a/CommonInputMethod/CIMInputController.swift
+++ b/CommonInputMethod/CIMInputController.swift
@@ -10,6 +10,7 @@ import Foundation
 
 extension CIMInputController {
     @IBAction func showStandardAboutPanel(_ sender: Any) {
+        NSApp.activate(ignoringOtherApps: true)
         NSApp.orderFrontStandardAboutPanel(sender)
     }
 }


### PR DESCRIPTION
Ref #360.

Obj-C에서 `[NSApp activateIgnoringOtherApps:YES]` 후 `orderFrontStandardAboutPanel`을 하니 창이 맨 앞으로 제대로 오는 것 같아 Swift로 옮겨보았습니다.