### PR TITLE
Fix detecting state of caps lock

### DIFF
--- a/CommonInputMethod/CIMInputController.m
+++ b/CommonInputMethod/CIMInputController.m
@@ -329,16 +329,16 @@ TISInputSource *_USSource() {
 
 // Receiving Events Directly from the Text Services Manager
 - (BOOL)handleEvent:(NSEvent *)event client:(id)sender {
-    if (event.type == NSKeyDown) {
+    if (event.type == NSEventTypeKeyDown) {
         dlog(DEBUG_INPUTCONTROLLER, @"** CIMInputController KEYDOWN -handleEvent:client: with event: %@ / key: %d / modifier: %lu / chars: %@ / chars ignoreMod: %@ / client: %@", event, [event keyCode], [event modifierFlags], [event characters], [event charactersIgnoringModifiers], [[self client] bundleIdentifier]);
         BOOL processed = [self->_receiver inputController:self inputText:event.characters key:event.keyCode modifiers:event.modifierFlags client:sender] > CIMInputTextProcessResultNotProcessed;
         dlog(DEBUG_LOGGING, @"LOGGING::PROCESSED::%d", processed);
         return processed;
     }
-    else if (event.type == NSFlagsChanged) {
-        NSEventModifierFlags modifierFlags = 0;
+    else if (event.type == NSEventTypeFlagsChanged) {
+        NSEventModifierFlags modifierFlags = event.modifierFlags;
         if (self->_ioConnect.capsLockState) {
-            modifierFlags |= NSAlphaShiftKeyMask;
+            modifierFlags |= NSEventModifierFlagCapsLock;
         }
         dlog(DEBUG_LOGGING, @"modifierFlags by IOKit: %lx", modifierFlags);
         //dlog(DEBUG_INPUTCONTROLLER, @"** CIMInputController FLAGCHANGED -handleEvent:client: with event: %@ / key: %d / modifier: %lu / chars: %@ / chars ignoreMod: %@ / client: %@", event, -1, modifierFlags, nil, nil, [[self client] bundleIdentifier]);


### PR DESCRIPTION
GureumComposer는 `flags.rawValue == 0`으로 캡스락이 꺼졌는지 확인하는데, `handleEvent`에서 나머지 `event.modifierFlags`를 무시하고 있어 다른 modifier 키만 누르거나 뗄 때에도 캡스락이 눌린 것처럼 동작합니다.

그 외에 `NSKeyDown` 등은 deprecated 상태여서 수정합니다.