### PR TITLE
Use default configuration on test

### DIFF
--- a/GureumTests/GureumObjCTests.m
+++ b/GureumTests/GureumObjCTests.m
@@ -32,11 +32,25 @@
 @end
 
 
+static NSString *domainName = @"org.youknowone.Gureum";
+static NSDictionary<NSString *, id> *oldConfiguration;
+
 @implementation GureumObjCTests
+
++ (void)setUp {
+    [super setUp];
+    oldConfiguration = [[NSUserDefaults standardUserDefaults] persistentDomainForName:domainName];
+}
+
++ (void)tearDown {
+    [[NSUserDefaults standardUserDefaults] setPersistentDomain:oldConfiguration forName:domainName];
+    [super tearDown];
+}
 
 - (void)setUp {
     [super setUp];
 
+    [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:domainName];
     self.moderate = [[ModerateApp alloc] init];
     self.terminal = [[TerminalApp alloc] init];
     self.greedy = [[GreedyApp alloc] init];

--- a/GureumTests/GureumTests.swift
+++ b/GureumTests/GureumTests.swift
@@ -12,15 +12,30 @@ import Hangul
 
 
 class GureumTests: XCTestCase {
+    static let domainName: String = "org.youknowone.Gureum"
+    static var oldConfiguration: [String : Any]?
     let moderate: VirtualApp = ModerateApp()
     let terminal: VirtualApp = TerminalApp()
     let greedy: VirtualApp = GreedyApp()
     var apps: [VirtualApp] = []
-    
+
+    override class func setUp() {
+        super.setUp()
+        self.oldConfiguration = UserDefaults.standard.persistentDomain(forName: self.domainName)
+    }
+
+    override class func tearDown() {
+        if let oldConfiguration = self.oldConfiguration {
+            UserDefaults.standard.setPersistentDomain(oldConfiguration, forName: self.domainName)
+        }
+        super.tearDown()
+    }
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
-        
+
+        UserDefaults.standard.removePersistentDomain(forName: GureumTests.domainName)
         self.apps = [self.moderate]
     }
     


### PR DESCRIPTION
로컬에서 테스트를 돌렸을 때 `testLayoutChange`나 `testBackQuoteHan2` 등이 실패해서 보니 실제 구름 환경 설정이 테스트에 영향을 주고 있는 것 같았습니다. 대부분의 테스트가 기본 설정임을 가정하고 작성된 것 같아 테스트 환경에선 기본 설정으로 리셋한 후 실행하도록 했습니다.