### PR TITLE
Fix romanModeByEscapeKey feature

### DIFF
--- a/OSX/GureumComposer.swift
+++ b/OSX/GureumComposer.swift
@@ -257,8 +257,11 @@ let GureumInputSourceToHangulKeyboardIdentifierTable: [GureumInputSourceIdentifi
                 emoticonComposer.update(fromController: controller)
                 return CIMInputTextProcessResult.processed
             }
+        }
+
+        if self.delegate === hangulComposer {
             // Vi-mode: esc로 로마자 키보드로 전환
-            if GureumConfiguration.shared.romanModeByEscapeKey && (keyCode == kVK_Escape || false) {
+            if GureumConfiguration.shared.romanModeByEscapeKey && keyCode == kVK_Escape {
                 self.delegate.cancelComposition()
                 (sender as AnyObject).selectMode(GureumConfiguration.shared.lastRomanInputMode)
                 return CIMInputTextProcessResult.notProcessedAndNeedsCommit


### PR DESCRIPTION
Ref #423.

https://github.com/gureum/gureum/commit/83962992c93e89e8634dcfb513ad507f2f5d2ce3 커밋에서 살짝 꼬인 것으로 보입니다. 추가로 Esc 키로 자판을 전환할 때에 `.notProcessedAndNeedsCommit`으로 보내면 입력기 바깥의 앱에 Esc 입력이 들어가 `.processed`로 변경했습니다. 생각해보니 장단점이 있는데 일부러 이렇게 두신 거라면 반환값은 다시 바꾸겠습니다.