### PR TITLE
Mapped Vi-mode's Escape with Ctrl+'['

### DIFF
--- a/GureumTests/GureumTests.swift
+++ b/GureumTests/GureumTests.swift
@@ -502,4 +502,25 @@ class GureumTests: XCTestCase {
         }
     }
 
+    func testEscapeOrCntrlAndLeftBracketHan3Gureum() {
+        for app in self.apps {
+            app.client.string = ""
+            app.controller.setValue(GureumInputSourceIdentifier.han3FinalNoShift.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
+            
+            app.inputText("[", key: Int(kVK_ANSI_LeftBracket), modifiers: NSEvent.ModifierFlags.control)
+            XCTAssertEqual("", app.client.string, "buffer: \(app.client.string) app: \(app)")
+        }
+    }
+    
+    func testEscapeOrCntrlAndLeftBracketWithShiftHan3Gureum() {
+        for app in self.apps {
+            let controlAndShift = NSEvent.ModifierFlags.control.union(.shift)
+            app.client.string = ""
+            app.controller.setValue(GureumInputSourceIdentifier.han3FinalNoShift.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
+            
+            app.inputText("[", key: Int(kVK_ANSI_LeftBracket), modifiers: controlAndShift)
+            XCTAssertEqual("", app.client.string, "buffer: \(app.client.string) app: \(app)")
+        }
+    }
+
 }

--- a/OSX/GureumComposer.swift
+++ b/OSX/GureumComposer.swift
@@ -261,7 +261,10 @@ let GureumInputSourceToHangulKeyboardIdentifierTable: [GureumInputSourceIdentifi
 
         if self.delegate === hangulComposer {
             // Vi-mode: esc로 로마자 키보드로 전환
-            if GureumConfiguration.shared.romanModeByEscapeKey && keyCode == kVK_Escape {
+            let controlPressed = !inputModifier.intersection(NSEvent.ModifierFlags.control).isEmpty
+            let shiftUnpressed = inputModifier.intersection(NSEvent.ModifierFlags.shift).isEmpty
+            let escapePressed = keyCode == kVK_Escape
+            if GureumConfiguration.shared.romanModeByEscapeKey && (escapePressed || (keyCode == kVK_ANSI_LeftBracket && shiftUnpressed && controlPressed)) {
                 self.delegate.cancelComposition()
                 (sender as AnyObject).selectMode(GureumConfiguration.shared.lastRomanInputMode)
                 return CIMInputTextProcessResult.notProcessedAndNeedsCommit


### PR DESCRIPTION
Vi모드에서  ESC키 대신 Cntl키와 '['키를 같이 누르는 것으로 영문으로 전환시킬 수 있도록 하였습니다.