### PR TITLE
Fabric Answer KPI 추가

### DIFF
--- a/OSX/EmoticonComposer.swift
+++ b/OSX/EmoticonComposer.swift
@@ -79,7 +79,7 @@ public class EmoticonComposer: CIMComposer {
         self._commitString = value
         self.romanComposer.cancelComposition()
         self.romanComposer.dequeueCommitString()
-        Answers.logCustomEvent("EmojiInput", customAttributes: ["Emoji":value])
+        Answers.logCustomEvent(withName: "EmojiInput", customAttributes: ["Emoji":value])
 
     }
 

--- a/OSX/EmoticonComposer.swift
+++ b/OSX/EmoticonComposer.swift
@@ -7,6 +7,7 @@
 //
 
 import Hangul
+import Crashlytics
 
 let DEBUG_EMOTICON = false
 
@@ -78,6 +79,8 @@ public class EmoticonComposer: CIMComposer {
         self._commitString = value
         self.romanComposer.cancelComposition()
         self.romanComposer.dequeueCommitString()
+        Answers.logCustomEvent("EmojiInput", customAttributes: ["Emoji":value])
+
     }
 
     override public func candidateSelectionChanged(_ candidateString: NSAttributedString) {

--- a/OSX/GureumAppDelegate.swift
+++ b/OSX/GureumAppDelegate.swift
@@ -16,6 +16,7 @@ class NotificationCenterDelegate: NSObject, NSUserNotificationCenterDelegate{
 
     override init(){
         super.init()
+        Fabric.with([Answers.self])
         NSUserNotificationCenter.default.delegate = self
     }
 
@@ -55,6 +56,13 @@ class NotificationCenterDelegate: NSObject, NSUserNotificationCenterDelegate{
         Fabric.with([Crashlytics.self])
         #endif
         checkUpdate()
+        logLastInputMode()
+    }
+    
+    func logLastInputMode() {
+        let lastRoman = self.configuration.lastRomanInputMode
+        let lastHangul = self.configuration.lastHangulInputMode
+        Answers.logCustomEvent(withName: "LastInputMode", customAttributes: ["Roman":lastRoman, "Hangul":lastHangul])
     }
 
     @objc func composer(server: IMKServer!, client: Any!) -> CIMComposer {

--- a/OSX/HanjaComposer.swift
+++ b/OSX/HanjaComposer.swift
@@ -69,6 +69,7 @@ class HanjaComposer: CIMComposer {
         self._commitString = value
         self.hangulComposer.cancelComposition()
         self.hangulComposer.dequeueCommitString()
+        Answers.logCustomEvent("HanjaInput", customAttributes: ["Hanja":value])
     }
 
     override func candidateSelectionChanged(_ candidateString: NSAttributedString) {

--- a/OSX/HanjaComposer.swift
+++ b/OSX/HanjaComposer.swift
@@ -7,6 +7,7 @@
 //
 
 import Hangul
+import Crashlytics
 
 let DEBUG_HANJACOMPOSER = false
 
@@ -69,7 +70,7 @@ class HanjaComposer: CIMComposer {
         self._commitString = value
         self.hangulComposer.cancelComposition()
         self.hangulComposer.dequeueCommitString()
-        Answers.logCustomEvent("HanjaInput", customAttributes: ["Hanja":value])
+        Answers.logCustomEvent(withName:"HanjaInput", customAttributes: ["Hanja":value])
     }
 
     override func candidateSelectionChanged(_ candidateString: NSAttributedString) {


### PR DESCRIPTION
1. 이모티콘, 한자 입력 시 custom Event를 만들어 해당 value 전송
2. 구름입력기 시작 시 기본으로 설정된 사용자의 입력소스 전송(입력소스 유형파악)

- 소프트웨어학과 이동영