### PR TITLE
Delay initialization of apps for testing configuration

### DIFF
--- a/GureumTests/GureumTests.swift
+++ b/GureumTests/GureumTests.swift
@@ -13,11 +13,11 @@ import XCTest
 
 class GureumTests: XCTestCase {
     static let domainName = "org.youknowone.Gureum.test"
-    let moderate: VirtualApp = ModerateApp()
-    // let xcode: VirtualApp = XcodeApp()
-    let terminal: VirtualApp! = nil
-//    let terminal: VirtualApp = TerminalApp()
-//    let greedy: VirtualApp = GreedyApp()
+    lazy var moderate: VirtualApp = ModerateApp()
+    // lazy var xcode: VirtualApp = XcodeApp()
+    lazy var terminal: VirtualApp! = nil
+    // lazy var terminal: VirtualApp = TerminalApp()
+    // lazy var greedy: VirtualApp = GreedyApp()
     lazy var apps: [VirtualApp] = [moderate]
 
     override class func setUp() {


### PR DESCRIPTION
``` swift
override class func setUp() {
    Configuration.shared = Configuration(suiteName: "org.youknowone.Gureum.test")!
    super.setUp()
}
```

위 코드가 제대로 적용되려면 `GureumTests` 아래에 있는 프로퍼티들이 저 클래스 `setUp()` 후에 초기화되어야 합니다.