### PR TITLE
Remove Optional() from description of update

### DIFF
--- a/Gureum.xcodeproj/project.pbxproj
+++ b/Gureum.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		80383E6D2161F0D300FC5FB6 /* hangul-keyboard-3-2012.xml in Copy Keyboards Files */ = {isa = PBXBuildFile; fileRef = 80383E6A2161F0D300FC5FB6 /* hangul-keyboard-3-2012.xml */; };
 		80383E6E2161F0D300FC5FB6 /* hangul-keyboard-3-2011.xml in Copy Keyboards Files */ = {isa = PBXBuildFile; fileRef = 80383E6B2161F0D300FC5FB6 /* hangul-keyboard-3-2011.xml */; };
 		80383E6F2161F0D300FC5FB6 /* hangul-combination-3p.xml in Copy Keyboards Files */ = {isa = PBXBuildFile; fileRef = 80383E6C2161F0D300FC5FB6 /* hangul-combination-3p.xml */; };
+		80983E8022AE2A7000A69C08 /* UpdateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3831983B21DB744900E20D78 /* UpdateManager.swift */; };
 		80A02B24217E1AA90018E658 /* hangul-keyboard-2y-full.xml in Copy Keyboards Files */ = {isa = PBXBuildFile; fileRef = 80A02B22217E1AA90018E658 /* hangul-keyboard-2y-full.xml */; };
 		80A02B25217E1AA90018E658 /* hangul-keyboard-2-full.xml in Copy Keyboards Files */ = {isa = PBXBuildFile; fileRef = 80A02B23217E1AA90018E658 /* hangul-keyboard-2-full.xml */; };
 		A34E20012168B21B00B12476 /* GureumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BAAE062160C6970076C66D /* GureumTests.swift */; };
@@ -1278,6 +1279,7 @@
 				A34E20012168B21B00B12476 /* GureumTests.swift in Sources */,
 				388186B521EB4E98004B7FDB /* MockApp.swift in Sources */,
 				3881866421EB23F3004B7FDB /* MockInputClient.m in Sources */,
+				80983E8022AE2A7000A69C08 /* UpdateManager.swift in Sources */,
 				38BFE80418B45419004B2B2E /* GureumObjCTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GureumTests/GureumTests.swift
+++ b/GureumTests/GureumTests.swift
@@ -11,6 +11,14 @@ import Hangul
 import InputMethodKit
 import XCTest
 
+private var lastNotification: NSUserNotification!
+
+extension NSUserNotificationCenter {
+    func deliver(_ notification: NSUserNotification) {
+        lastNotification = notification
+    }
+}
+
 class GureumTests: XCTestCase {
     static let domainName = "org.youknowone.Gureum.test"
     lazy var moderate: VirtualApp = ModerateApp()
@@ -46,6 +54,24 @@ class GureumTests: XCTestCase {
         let bundle = NSPrefPaneBundle(path: path)!
         let loaded = bundle.instantiatePrefPaneObject()
         XCTAssertTrue(loaded)
+    }
+
+    func testNotifyUpdate() {
+        let versionInfoString = """
+        {
+            "version": "1.10.0",
+            "description": "Mojave 대응을 포함한 대형 업데이트",
+            "url": "https://github.com/gureum/gureum/releases/tag/1.10.0"
+        }
+        """
+        guard let versionInfoJSON = try? JSONSerialization.jsonObject(with: versionInfoString) as? [String: String] else {
+            XCTFail()
+            return
+        }
+        let versionInfo = UpdateManager.VersionInfo(data: versionInfoJSON)
+        UpdateManager.shared.notifyUpdate(info: versionInfo)
+        XCTAssertEqual("최신 버전: 1.10.0 현재 버전: \(UpdateManager.bundleVersion ?? "-")\nMojave 대응을 포함한 대형 업데이트", lastNotification.informativeText)
+        XCTAssertEqual(["url": "https://github.com/gureum/gureum/releases/tag/1.10.0"], lastNotification.userInfo as! [String: String])
     }
 
     func testLayoutChange() {

--- a/OSX/UpdateManager.swift
+++ b/OSX/UpdateManager.swift
@@ -80,7 +80,7 @@ class UpdateManager {
         notification.hasReplyButton = false
         notification.actionButtonTitle = "업데이트"
         notification.otherButtonTitle = "취소"
-        notification.informativeText = "최신 버전: \(info.recent ?? "-") 현재 버전: \(info.current ?? "-")\n\(info.description)"
+        notification.informativeText = "최신 버전: \(info.recent ?? "-") 현재 버전: \(info.current ?? "-")\n\(info.description ?? "")"
         if let url = info.url {
             // URL object is not delivered
             notification.userInfo = ["url": url.absoluteString]


### PR DESCRIPTION
최신 업데이트 설명에 "Optional()"이 표시되어 수정했습니다.

![Screenshot 2019-06-10 16 07 43](https://user-images.githubusercontent.com/853977/59178485-1381aa00-8b9a-11e9-86c7-8031a6591f72.png)

처음 구현은 `NSUserNotificationCenter` 안에 `var lastNotification: NSUserNotification!`을 추가하려 하였으나 extension에는 stored properties를 추가할 수 없더군요.
https://marcosantadev.com/stored-properties-swift-extensions/ 등으로 해결할 수 있는 것 같았으나 그렇게까지 할 필요가 있을까 싶어 일단은 지금과 같은 방식으로 구현했습니다.