### PR TITLE
Fall back to default identifier of .han2

### DIFF
--- a/OSXCore/GureumComposer.swift
+++ b/OSXCore/GureumComposer.swift
@@ -68,7 +68,7 @@ class GureumComposer: DelegatedComposer {
     let qwertyComposer: QwertyComposer = QwertyComposer()
     let dvorakComposer: RomanDataComposer = RomanDataComposer(keyboardData: RomanDataComposer.dvorakData)
     let colemakComposer: RomanDataComposer = RomanDataComposer(keyboardData: RomanDataComposer.colemakData)
-    let hangulComposer: HangulComposer = HangulComposer(keyboardIdentifier: "2")!
+    let hangulComposer: HangulComposer = HangulComposer(keyboardIdentifier: GureumInputSourceToHangulKeyboardIdentifierTable[.han2]!)!
     let hanjaComposer: HanjaComposer = HanjaComposer()
     let emoticonComposer: EmoticonComposer = EmoticonComposer()
     let romanComposersByIdentifier: [String: DelegatedComposer]

--- a/OSXCore/HangulComposer.swift
+++ b/OSXCore/HangulComposer.swift
@@ -94,7 +94,7 @@ class HangulComposer: NSObject, ComposerDelegate {
 
     override func observeValue(forKeyPath keyPath: String?, of _: Any?, change _: [NSKeyValueChangeKey: Any]?, context _: UnsafeMutableRawPointer?) {
         if keyPath == ConfigurationName.hangulForceStrictCombinationRule.rawValue {
-            let keyboard = GureumInputSourceIdentifier(rawValue: configuration.lastHangulInputMode)?.keyboardIdentifier ?? "2"
+            let keyboard = GureumInputSourceIdentifier(rawValue: configuration.lastHangulInputMode)?.keyboardIdentifier ?? GureumInputSourceToHangulKeyboardIdentifierTable[.han2]!
             setKeyboard(identifier: keyboard)
         } else {
             inputContext.setOption(HANGUL_IC_OPTION_AUTO_REORDER, value: configuration.hangulAutoReorder)


### PR DESCRIPTION
현재 `.han2` 자판의 keyboard identifier는 "2-full"입니다.