### PR TITLE
Remove unusable keyboards

### DIFF
--- a/OSX/Info.plist
+++ b/OSX/Info.plist
@@ -154,48 +154,6 @@
 				<key>tsInputModeScriptKey</key>
 				<string>smKorean</string>
 			</dict>
-			<key>org.youknowone.inputmethod.Gureum.han3-2014</key>
-			<dict>
-				<key>TISInputSourceID</key>
-				<string>org.youknowone.inputmethod.Gureum.han3-2014</string>
-				<key>TISIntendedLanguage</key>
-				<string>ko</string>
-				<key>tsInputModeAlternateMenuIconFileKey</key>
-				<string>han3.png</string>
-				<key>tsInputModeDefaultStateKey</key>
-				<false/>
-				<key>tsInputModeIsVisibleKey</key>
-				<true/>
-				<key>tsInputModeMenuIconFileKey</key>
-				<string>han3.png</string>
-				<key>tsInputModePaletteIconFileKey</key>
-				<string>han3.png</string>
-				<key>tsInputModePrimaryInScriptKey</key>
-				<false/>
-				<key>tsInputModeScriptKey</key>
-				<string>smKorean</string>
-			</dict>
-			<key>org.youknowone.inputmethod.Gureum.han3-2015</key>
-			<dict>
-				<key>TISInputSourceID</key>
-				<string>org.youknowone.inputmethod.Gureum.han3-2015</string>
-				<key>TISIntendedLanguage</key>
-				<string>ko</string>
-				<key>tsInputModeAlternateMenuIconFileKey</key>
-				<string>han3.png</string>
-				<key>tsInputModeDefaultStateKey</key>
-				<false/>
-				<key>tsInputModeIsVisibleKey</key>
-				<true/>
-				<key>tsInputModeMenuIconFileKey</key>
-				<string>han3.png</string>
-				<key>tsInputModePaletteIconFileKey</key>
-				<string>han3.png</string>
-				<key>tsInputModePrimaryInScriptKey</key>
-				<false/>
-				<key>tsInputModeScriptKey</key>
-				<string>smKorean</string>
-			</dict>
 			<key>org.youknowone.inputmethod.Gureum.han390</key>
 			<dict>
 				<key>TISInputSourceID</key>
@@ -410,8 +368,6 @@
 			<string>org.youknowone.inputmethod.Gureum.han3finalnoshift</string>
 			<string>org.youknowone.inputmethod.Gureum.han3-2011</string>
 			<string>org.youknowone.inputmethod.Gureum.han3-2012</string>
-			<string>org.youknowone.inputmethod.Gureum.han3-2014</string>
-			<string>org.youknowone.inputmethod.Gureum.han3-2015</string>
 		</array>
 	</dict>
 	<key>Fabric</key>

--- a/OSX/en.lproj/InfoPlist.strings
+++ b/OSX/en.lproj/InfoPlist.strings
@@ -15,8 +15,6 @@ org.youknowone.inputmethod.Gureum.hanahnmatae = "Han Ahnmatae";
 org.youknowone.inputmethod.Gureum.han3finalnoshift = "Han 3set Final No shift (Gureum)";
 org.youknowone.inputmethod.Gureum.han3-2011 = "Han 3set 2011";
 org.youknowone.inputmethod.Gureum.han3-2012 = "Han 3set 2012";
-org.youknowone.inputmethod.Gureum.han3-2014 = "Han 3set Moachigi 2015";
-org.youknowone.inputmethod.Gureum.han3-2015 = "Han 3set 2015";
 
 CFBundleName = "Gureum";
 CFBundleDisplayName = "Gureum Input Method";

--- a/OSX/ko.lproj/InfoPlist.strings
+++ b/OSX/ko.lproj/InfoPlist.strings
@@ -15,8 +15,6 @@ org.youknowone.inputmethod.Gureum.hanahnmatae = "안마태";
 org.youknowone.inputmethod.Gureum.han3-2011 = "세벌식 2011";
 org.youknowone.inputmethod.Gureum.han3-2012 = "세벌식 2012";
 org.youknowone.inputmethod.Gureum.han3finalnoshift = "세벌식 최종 순아래";
-org.youknowone.inputmethod.Gureum.han3-2014 = "세벌식 모아치기 2015";
-org.youknowone.inputmethod.Gureum.han3-2015 = "세벌식 2015";
 
 CFBundleName = "구름";
 CFBundleDisplayName = "구름 입력기";

--- a/OSXCore/GureumComposer.swift
+++ b/OSXCore/GureumComposer.swift
@@ -31,8 +31,6 @@ enum GureumInputSourceIdentifier: String {
     case han3FinalNoShift = "org.youknowone.inputmethod.Gureum.han3finalnoshift"
     case han3_2011 = "org.youknowone.inputmethod.Gureum.han3-2011"
     case han3_2012 = "org.youknowone.inputmethod.Gureum.han3-2012"
-    case han3_2014 = "org.youknowone.inputmethod.Gureum.han3-2014"
-    case han3_2015 = "org.youknowone.inputmethod.Gureum.han3-2015"
 
     var keyboardIdentifier: String {
         guard let value = GureumInputSourceToHangulKeyboardIdentifierTable[self] else {
@@ -59,8 +57,6 @@ let GureumInputSourceToHangulKeyboardIdentifierTable: [GureumInputSourceIdentifi
     .han3FinalNoShift: "3gs",
     .han3_2011: "3-2011",
     .han3_2012: "3-2012",
-    .han3_2014: "3-2014",
-    .han3_2015: "3-2015",
 ]
 
 class GureumComposer: DelegatedComposer {


### PR DESCRIPTION
세벌식 모아치기 2015와 세벌식 2015 자판은 현재 libhangul의 xml 등으로 구현할 수 없고, 자판을 추가해도 영문으로만 입력됩니다.