### PR TITLE
Check before unwrapping globalPreferences

### DIFF
--- a/OSXCore/SystemConfigurationWatcher.swift
+++ b/OSXCore/SystemConfigurationWatcher.swift
@@ -32,7 +32,10 @@ public class SystemConfigurationWatcher {
     }
 
     public func reloadConfiguration() {
-        let globalPreferences = NSDictionary(contentsOf: URL(fileURLWithPath: SystemConfigurationWatcher.globalPreferencesPath))!
+        guard let globalPreferences = NSDictionary(contentsOf: URL(fileURLWithPath: SystemConfigurationWatcher.globalPreferencesPath)) else {
+            return
+        }
+
         let state: Int = (globalPreferences["TISRomanSwitchState"] as? NSNumber)?.intValue ?? 1
         configuration.enableCapslockToToggleInputMode = state > 0
     }


### PR DESCRIPTION
직접 확인해보진 않았지만 ~/Library/Preferences/.GlobalPreferences.plist 파일이 존재하지 않는다면 `globalPreferences`에 nil이 들어갈 수 있을 것 같습니다.

이 이슈와 관련 있을 것 같습니다.

```
# URL: https://fabric.io/youknowoneorg/mac/apps/org.youknowone.inputmethod.gureum/issues/5cebe50cf8b88c29630a2378?time=1561420800000%3A1561507199000/sessions/3ed25621f751455083d225eb34335e14_DNE_0_v2
# Organization: youknowone.org
# Platform: mac_os_x
# Application: 구름 입력기
# Version: 1.10.1
# Bundle Identifier: org.youknowone.inputmethod.Gureum
# Issue ID: 5cebe50cf8b88c29630a2378
# Session ID: 3ed25621f751455083d225eb34335e14_DNE_0_v2
# Date: 2019-06-25T14:51:00Z
# OS Version: 10.14.5 (18F132)
# Device: MacBook Pro Retina, 15", Early 2013
# RAM Free: 46.7%
# Disk Free: 13.4%

#0. Crashed: com.apple.main-thread
0  GureumCore                     0x107720b21 $s10GureumCore26SystemConfigurationWatcherC06reloadD0yyF + 529
1  Gureum                         0x1075a9d04 GureumAppDelegate.applicationDidFinishLaunching(_:) (<compiler-generated>)
2  Gureum                         0x1075a9e2e @objc GureumAppDelegate.applicationDidFinishLaunching(_:) (<compiler-generated>)
3  CoreFoundation                 0x7fff4a4a537a __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 12
4  CoreFoundation                 0x7fff4a4a52f4 ___CFXRegistrationPost_block_invoke + 63
5  CoreFoundation                 0x7fff4a4a525e _CFXRegistrationPost + 404
6  CoreFoundation                 0x7fff4a4ad68d ___CFXNotificationPost_block_invoke + 87
7  CoreFoundation                 0x7fff4a41676c -[_CFXNotificationRegistrar find:object:observer:enumerator:] + 1834
8  CoreFoundation                 0x7fff4a415a17 _CFXNotificationPost + 840
9  Foundation                     0x7fff4c6b906b -[NSNotificationCenter postNotificationName:object:userInfo:] + 66
10 AppKit                         0x7fff47ac11a8 -[NSApplication _postDidFinishNotification] + 312
11 AppKit                         0x7fff47ac0afb -[NSApplication _sendFinishLaunchingNotification] + 208
12 AppKit                         0x7fff47abec4f -[NSApplication(NSAppleEventHandling) _handleAEOpenEvent:] + 552
13 AppKit                         0x7fff47abe89f -[NSApplication(NSAppleEventHandling) _handleCoreEvent:withReplyEvent:] + 688
14 Foundation                     0x7fff4c702bec -[NSAppleEventManager dispatchRawAppleEvent:withRawReply:handlerRefCon:] + 286
15 Foundation                     0x7fff4c702a69 _NSAppleEventManagerGenericHandler + 102
16 AE                             0x7fff4b684397 aeDispatchAppleEvent(AEDesc const*, AEDesc*, unsigned int, unsigned char*) + 1815
17 AE                             0x7fff4b683c29 dispatchEventAndSendReply(AEDesc const*, AEDesc*) + 41
18 AE                             0x7fff4b683b01 aeProcessAppleEvent + 414
19 HIToolbox                      0x7fff49729e97 AEProcessAppleEvent + 54
20 AppKit                         0x7fff47abac7e _DPSNextEvent + 1724
21 AppKit                         0x7fff47ab971f -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1361
22 AppKit                         0x7fff47ab383c -[NSApplication run] + 699
23 Gureum                         0x1075a74ad main (<compiler-generated>)
24 libdyld.dylib                  0x7fff764063d5 start + 1

--

#0. Crashed: com.apple.main-thread
0  GureumCore                     0x107720b21 $s10GureumCore26SystemConfigurationWatcherC06reloadD0yyF + 529
1  Gureum                         0x1075a9d04 GureumAppDelegate.applicationDidFinishLaunching(_:) (<compiler-generated>)
2  Gureum                         0x1075a9e2e @objc GureumAppDelegate.applicationDidFinishLaunching(_:) (<compiler-generated>)
3  CoreFoundation                 0x7fff4a4a537a __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 12
4  CoreFoundation                 0x7fff4a4a52f4 ___CFXRegistrationPost_block_invoke + 63
5  CoreFoundation                 0x7fff4a4a525e _CFXRegistrationPost + 404
6  CoreFoundation                 0x7fff4a4ad68d ___CFXNotificationPost_block_invoke + 87
7  CoreFoundation                 0x7fff4a41676c -[_CFXNotificationRegistrar find:object:observer:enumerator:] + 1834
8  CoreFoundation                 0x7fff4a415a17 _CFXNotificationPost + 840
9  Foundation                     0x7fff4c6b906b -[NSNotificationCenter postNotificationName:object:userInfo:] + 66
10 AppKit                         0x7fff47ac11a8 -[NSApplication _postDidFinishNotification] + 312
11 AppKit                         0x7fff47ac0afb -[NSApplication _sendFinishLaunchingNotification] + 208
12 AppKit                         0x7fff47abec4f -[NSApplication(NSAppleEventHandling) _handleAEOpenEvent:] + 552
13 AppKit                         0x7fff47abe89f -[NSApplication(NSAppleEventHandling) _handleCoreEvent:withReplyEvent:] + 688
14 Foundation                     0x7fff4c702bec -[NSAppleEventManager dispatchRawAppleEvent:withRawReply:handlerRefCon:] + 286
15 Foundation                     0x7fff4c702a69 _NSAppleEventManagerGenericHandler + 102
16 AE                             0x7fff4b684397 aeDispatchAppleEvent(AEDesc const*, AEDesc*, unsigned int, unsigned char*) + 1815
17 AE                             0x7fff4b683c29 dispatchEventAndSendReply(AEDesc const*, AEDesc*) + 41
18 AE                             0x7fff4b683b01 aeProcessAppleEvent + 414
19 HIToolbox                      0x7fff49729e97 AEProcessAppleEvent + 54
20 AppKit                         0x7fff47abac7e _DPSNextEvent + 1724
21 AppKit                         0x7fff47ab971f -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1361
22 AppKit                         0x7fff47ab383c -[NSApplication run] + 699
23 Gureum                         0x1075a74ad main (<compiler-generated>)
24 libdyld.dylib                  0x7fff764063d5 start + 1

#1. Thread
0  libsystem_kernel.dylib         0x7fff7653cbfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff765f9636 _pthread_wqthread + 458
2  libsystem_pthread.dylib        0x7fff765f93fd start_wqthread + 13

#2. io.answers.EventQueue (QOS: BACKGROUND)
0  libsystem_kernel.dylib         0x7fff7653c206 close + 10
1  libz.1.dylib                   0x7fff75a9fa34 gzclose_w + 165
2  Gureum                         0x1075d8ef7 -[ANSCompressLogOperation main] + 578
3  Foundation                     0x7fff4c6d31dd -[__NSOperationInternal _start:] + 685
4  Foundation                     0x7fff4c6fd197 __NSOQSchedule_f + 227
5  libdispatch.dylib              0x7fff763b85f8 _dispatch_call_block_and_release + 12
6  libdispatch.dylib              0x7fff763b963d _dispatch_client_callout + 8
7  libdispatch.dylib              0x7fff763bbde6 _dispatch_continuation_pop + 414
8  libdispatch.dylib              0x7fff763bb4a3 _dispatch_async_redirect_invoke + 703
9  libdispatch.dylib              0x7fff763c73bc _dispatch_root_queue_drain + 324
10 libdispatch.dylib              0x7fff763c7b46 _dispatch_worker_thread2 + 90
11 libsystem_pthread.dylib        0x7fff765f96b3 _pthread_wqthread + 583
12 libsystem_pthread.dylib        0x7fff765f93fd start_wqthread + 13
13 (Missing)                      0x54485244 (Missing)

#3. Thread
0  libsystem_kernel.dylib         0x7fff7653cbfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff765f9636 _pthread_wqthread + 458
2  libsystem_pthread.dylib        0x7fff765f93fd start_wqthread + 13
3  (Missing)                      0x2400001200 (Missing)

#4. Thread
0  libsystem_pthread.dylib        0x7fff765f93f0 _pthread_workqueue_addthreads + 59

#5. Thread
0  libsystem_kernel.dylib         0x7fff7653cbfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff765f96e6 _pthread_wqthread + 634
2  libsystem_pthread.dylib        0x7fff765f93fd start_wqthread + 13
3  (Missing)                      0x54485244 (Missing)

#6. com.twitter.crashlytics.mac.MachExceptionServer
0  Gureum                         0x1075c68de CLSProcessRecordAllThreads + 193
1  Gureum                         0x1075c6cd9 CLSProcessRecordAllThreads + 1212
2  Gureum                         0x1075b6259 CLSHandler + 45
3  Gureum                         0x1075b17a4 CLSMachExceptionServer + 1241
4  libsystem_pthread.dylib        0x7fff765fa2eb _pthread_body + 126
5  libsystem_pthread.dylib        0x7fff765fd249 _pthread_start + 66
6  libsystem_pthread.dylib        0x7fff765f940d thread_start + 13
```