### PR TITLE
Fix RomanDataComposer to ignore whitespace keys

### DIFF
--- a/OSXCore/RomanComposer.swift
+++ b/OSXCore/RomanComposer.swift
@@ -151,7 +151,13 @@ class RomanDataComposer: DelegatedComposer {
             } else {
                 newChr = chr
             }
-            _commitString = String(map[newChr]!)
+
+            guard let mappedChr = map[newChr] else {
+                _commitString = nil
+                return .notProcessed
+            }
+
+            _commitString = String(mappedChr)
             return .processed
         } else {
             _commitString = nil


### PR DESCRIPTION
InputReceiver의 input2에서 keyCode가 Return(0x24), Tab(0x30), Space(0x31)인 경우([키코드 목록](https://gist.github.com/eegrok/949034)), `string = KeyMapUpper[keyCode] ?? string` 또는 `string = KeyMapLower[keyCode] ?? string`이 실행되는데, `KeyMapUpper` 및 `KeyMapLower`에는 Return, Tab, Space에 해당하는 값이 nil로 들어가 있으나 `?? string`으로 인해 원래 값이 composer로 넘어가게 됩니다.

RomanDataComposer의 input에서 다음 구문으로 인해 크래시가 나는 것 같습니다. `map`에는 `KeyMapUpper`, `KeyMapLower`와 마찬가지로 Return, Tab, Space에 대한 값이 없습니다.

``` swift
if !string.isEmpty, keyCode < 0x33, !flags.contains(.option) {
    let newChr: Character
    let chr = string.first!
    if flags.contains(.capsLock), chr >= "a", chr <= "z" {
        newChr = Character(UnicodeScalar(String(chr).unicodeScalars.first!.value - 0x20)!)
    } else {
        newChr = chr
    }
    _commitString = String(map[newChr]!)
    return .processed
}
```

`string = KeyMapUpper[keyCode] ?? string` 등을 `string = KeyMapUpper[keyCode]`로 고칠 수도 있을 것 같은데, 동작이 달라질 것 같아 그대로 둡니다.

다음 이슈를 고칩니다.

```
# URL: https://fabric.io/youknowoneorg/mac/apps/org.youknowone.inputmethod.gureum/issues/5ce83658f8b88c2963d07349?time=1561593600000%3A1561679999000/sessions/78fc2907e4fc423e9c76c84d567ff44a_DNE_0_v2
# Organization: youknowone.org
# Platform: mac_os_x
# Application: 구름 입력기
# Version: 1.10.1
# Bundle Identifier: org.youknowone.inputmethod.Gureum
# Issue ID: 5ce83658f8b88c2963d07349
# Session ID: 78fc2907e4fc423e9c76c84d567ff44a_DNE_0_v2
# Date: 2019-06-27T16:14:00Z
# OS Version: 10.14.5 (18F132)
# Device: MacBook Pro Retina, 15", Mid 2014
# RAM Free: 73.4%
# Disk Free: 56.1%

#0. Crashed: com.apple.main-thread
0  GureumCore                     0x10c995e87 $s10GureumCore17RomanDataComposerC5input4text3key9modifiers6clientAA11InputResultVSSSg_SiSo20NSEventModifierFlagsVSo07IMKTextK0_So014IMKUnicodeTextK0ptF + 2231
1  GureumCore                     0x10c994b35 $s10GureumCore17DelegatedComposerCAA17InputTextDelegateA2aDP5input4text3key9modifiers6clientAA0E6ResultVSSSg_SiSo20NSEventModifierFlagsVSo07IMKTextE0_So010IMKUnicodefE0ptFTW + 21
2  GureumCore                     0x10c9ad0b6 $s10GureumCore13InputReceiverC6input24text3key9modifiers6clientAA0C6ResultVSSSg_SiSo20NSEventModifierFlagsVSo07IMKTextC0_So014IMKUnicodeTextC0ptF + 1638
3  GureumCore                     0x10c9ad7b5 $s10GureumCore13InputReceiverC5input4text3key9modifiers6clientAA0C6ResultVSSSg_SiSo20NSEventModifierFlagsVSo07IMKTextC0_So014IMKUnicodeTextC0ptF + 1493
4  GureumCore                     0x10c999eab $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptF + 3643
5  GureumCore                     0x10c99a6dc $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptFTo + 76
6  InputMethodKit                 0x10ca490a8 -[IMKServer handleEvent_Common:characterIndex:edge:clientWrapper:controller:] + 1350
7  InputMethodKit                 0x10ca3dfbd __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke_2 + 690
8  ViewBridge                     0x7fff69ed7f8e +[NSServiceViewController withHostProcessIdentifier:invoke:] + 41
9  InputMethodKit                 0x10ca3dd00 __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke + 143
10 InputMethodKit                 0x10ca4a7da __IMKXPCPerformBlockOnMainThread_block_invoke + 25
11 CoreFoundation                 0x7fff42476164 __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
12 CoreFoundation                 0x7fff42439887 __CFRunLoopDoBlocks + 394
13 CoreFoundation                 0x7fff424395e4 __CFRunLoopRun + 2772
14 CoreFoundation                 0x7fff424388be CFRunLoopRunSpecific + 455
15 HIToolbox                      0x7fff4172496b RunCurrentEventLoopInMode + 292
16 HIToolbox                      0x7fff417246a5 ReceiveNextEventCommon + 603
17 HIToolbox                      0x7fff41724436 _BlockUntilNextEventMatchingListInModeWithFilter + 64
18 AppKit                         0x7fff3fabe987 _DPSNextEvent + 965
19 AppKit                         0x7fff3fabd71f -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1361
20 AppKit                         0x7fff3fab783c -[NSApplication run] + 699
21 Gureum                         0x10c82e4ad main (<compiler-generated>)
22 libdyld.dylib                  0x7fff6e3633d5 start + 1

--

#0. Crashed: com.apple.main-thread
0  GureumCore                     0x10c995e87 $s10GureumCore17RomanDataComposerC5input4text3key9modifiers6clientAA11InputResultVSSSg_SiSo20NSEventModifierFlagsVSo07IMKTextK0_So014IMKUnicodeTextK0ptF + 2231
1  GureumCore                     0x10c994b35 $s10GureumCore17DelegatedComposerCAA17InputTextDelegateA2aDP5input4text3key9modifiers6clientAA0E6ResultVSSSg_SiSo20NSEventModifierFlagsVSo07IMKTextE0_So010IMKUnicodefE0ptFTW + 21
2  GureumCore                     0x10c9ad0b6 $s10GureumCore13InputReceiverC6input24text3key9modifiers6clientAA0C6ResultVSSSg_SiSo20NSEventModifierFlagsVSo07IMKTextC0_So014IMKUnicodeTextC0ptF + 1638
3  GureumCore                     0x10c9ad7b5 $s10GureumCore13InputReceiverC5input4text3key9modifiers6clientAA0C6ResultVSSSg_SiSo20NSEventModifierFlagsVSo07IMKTextC0_So014IMKUnicodeTextC0ptF + 1493
4  GureumCore                     0x10c999eab $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptF + 3643
5  GureumCore                     0x10c99a6dc $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptFTo + 76
6  InputMethodKit                 0x10ca490a8 -[IMKServer handleEvent_Common:characterIndex:edge:clientWrapper:controller:] + 1350
7  InputMethodKit                 0x10ca3dfbd __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke_2 + 690
8  ViewBridge                     0x7fff69ed7f8e +[NSServiceViewController withHostProcessIdentifier:invoke:] + 41
9  InputMethodKit                 0x10ca3dd00 __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke + 143
10 InputMethodKit                 0x10ca4a7da __IMKXPCPerformBlockOnMainThread_block_invoke + 25
11 CoreFoundation                 0x7fff42476164 __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
12 CoreFoundation                 0x7fff42439887 __CFRunLoopDoBlocks + 394
13 CoreFoundation                 0x7fff424395e4 __CFRunLoopRun + 2772
14 CoreFoundation                 0x7fff424388be CFRunLoopRunSpecific + 455
15 HIToolbox                      0x7fff4172496b RunCurrentEventLoopInMode + 292
16 HIToolbox                      0x7fff417246a5 ReceiveNextEventCommon + 603
17 HIToolbox                      0x7fff41724436 _BlockUntilNextEventMatchingListInModeWithFilter + 64
18 AppKit                         0x7fff3fabe987 _DPSNextEvent + 965
19 AppKit                         0x7fff3fabd71f -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1361
20 AppKit                         0x7fff3fab783c -[NSApplication run] + 699
21 Gureum                         0x10c82e4ad main (<compiler-generated>)
22 libdyld.dylib                  0x7fff6e3633d5 start + 1

#1. com.twitter.crashlytics.mac.MachExceptionServer
0  Gureum                         0x10c84d8de CLSProcessRecordAllThreads + 193
1  Gureum                         0x10c84dcd9 CLSProcessRecordAllThreads + 1212
2  Gureum                         0x10c83d259 CLSHandler + 45
3  Gureum                         0x10c8387a4 CLSMachExceptionServer + 1241
4  libsystem_pthread.dylib        0x7fff6e5572eb _pthread_body + 126
5  libsystem_pthread.dylib        0x7fff6e55a249 _pthread_start + 66
6  libsystem_pthread.dylib        0x7fff6e55640d thread_start + 13

#2. com.apple.NSEventThread
0  libsystem_kernel.dylib         0x7fff6e49822a mach_msg_trap + 10
1  libsystem_kernel.dylib         0x7fff6e49876c mach_msg + 60
2  CoreFoundation                 0x7fff42439bee __CFRunLoopServiceMachPort + 328
3  CoreFoundation                 0x7fff4243915c __CFRunLoopRun + 1612
4  CoreFoundation                 0x7fff424388be CFRunLoopRunSpecific + 455
5  AppKit                         0x7fff3fac66a6 _NSEventThread + 175
6  libsystem_pthread.dylib        0x7fff6e5572eb _pthread_body + 126
7  libsystem_pthread.dylib        0x7fff6e55a249 _pthread_start + 66
8  libsystem_pthread.dylib        0x7fff6e55640d thread_start + 13

#3. com.apple.NSURLConnectionLoader
0  libsystem_kernel.dylib         0x7fff6e49822a mach_msg_trap + 10
1  libsystem_kernel.dylib         0x7fff6e49876c mach_msg + 60
2  CoreFoundation                 0x7fff42439bee __CFRunLoopServiceMachPort + 328
3  CoreFoundation                 0x7fff4243915c __CFRunLoopRun + 1612
4  CoreFoundation                 0x7fff424388be CFRunLoopRunSpecific + 455
5  CFNetwork                      0x7fff413ac380 -[__CoreSchedulingSetRunnable runForever] + 210
6  Foundation                     0x7fff446926d2 __NSThread__start__ + 1194
7  libsystem_pthread.dylib        0x7fff6e5572eb _pthread_body + 126
8  libsystem_pthread.dylib        0x7fff6e55a249 _pthread_start + 66
9  libsystem_pthread.dylib        0x7fff6e55640d thread_start + 13

#4. Thread
0  libsystem_kernel.dylib         0x7fff6e499bfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff6e5566e6 _pthread_wqthread + 634
2  libsystem_pthread.dylib        0x7fff6e5563fd start_wqthread + 13
3  (Missing)                      0x54485244 (Missing)
```