### PR TITLE
Check when unwrapping selectionKeys()

### DIFF
--- a/OSXCore/InputController.swift
+++ b/OSXCore/InputController.swift
@@ -110,10 +110,10 @@ public extension InputController { // IMKServerInputHandleEvent
         // dlog(DEBUG_INPUTCONTROLLER, "event: \(event)")
         // sender is (IMKTextInput & IMKUnicodeTextInput & IMTSMSupport)
         let client = asClient(sender)
-        let imkCandidtes = InputMethodServer.shared.candidates
-        let keys = imkCandidtes.selectionKeys() as! [NSNumber]
-        if event.type == .keyDown, imkCandidtes.isVisible(), keys.contains(NSNumber(value: event.keyCode)) {
-            imkCandidtes.interpretKeyEvents([event])
+        let imkCandidates = InputMethodServer.shared.candidates
+        let keys = imkCandidates.selectionKeys() as? [NSNumber] ?? []
+        if event.type == .keyDown, imkCandidates.isVisible(), keys.contains(NSNumber(value: event.keyCode)) {
+            imkCandidates.interpretKeyEvents([event])
             return true
         }
         switch event.type {


### PR DESCRIPTION
[selectionKeys() - IMKCandidates](https://developer.apple.com/documentation/inputmethodkit/imkcandidates/1385537-selectionkeys):
> Returns an array of NSNumber objects where each NSNumber object represents a virtual key code.
> ``` swift
> func selectionKeys() -> [Any]!
> ```

다음 이슈와 관련이 있을 수 있습니다.

<details><p>

```
# URL: https://fabric.io/youknowoneorg/mac/apps/org.youknowone.inputmethod.gureum/issues/0b247e8c9f8ecf9f5185dad9da0392fe?time=1562112000000%3A1562198399000/sessions/f471a6e6a91542fcb95486a9883c0c47_DNE_0_v2
# Organization: youknowone.org
# Platform: mac_os_x
# Application: 구름 입력기
# Version: 1.10.1
# Bundle Identifier: org.youknowone.inputmethod.Gureum
# Issue ID: 0b247e8c9f8ecf9f5185dad9da0392fe
# Session ID: f471a6e6a91542fcb95486a9883c0c47_DNE_0_v2
# Date: 2019-07-03T12:22:00Z
# OS Version: 10.14.5 (18F132)
# Device: iMac Retina 5K, 27", Mid 2017
# RAM Free: 8.1%
# Disk Free: 26.5%

#0. Crashed: com.apple.main-thread
0  GureumCore                     0x10a6c145c $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptF + 5100
1  GureumCore                     0x10a6c16dc $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptFTo + 76
2  InputMethodKit                 0x10a7740a8 -[IMKServer handleEvent_Common:characterIndex:edge:clientWrapper:controller:] + 1350
3  InputMethodKit                 0x10a768fbd __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke_2 + 690
4  ViewBridge                     0x7fff6e09ff8e +[NSServiceViewController withHostProcessIdentifier:invoke:] + 41
5  InputMethodKit                 0x10a768d00 __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke + 143
6  InputMethodKit                 0x10a7757da __IMKXPCPerformBlockOnMainThread_block_invoke + 25
7  CoreFoundation                 0x7fff4663a164 __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
8  CoreFoundation                 0x7fff465fd887 __CFRunLoopDoBlocks + 394
9  CoreFoundation                 0x7fff465fd5e4 __CFRunLoopRun + 2772
10 CoreFoundation                 0x7fff465fc8be CFRunLoopRunSpecific + 455
11 HIToolbox                      0x7fff458e896b RunCurrentEventLoopInMode + 292
12 HIToolbox                      0x7fff458e86a5 ReceiveNextEventCommon + 603
13 HIToolbox                      0x7fff458e8436 _BlockUntilNextEventMatchingListInModeWithFilter + 64
14 AppKit                         0x7fff43c82987 _DPSNextEvent + 965
15 AppKit                         0x7fff43c8171f -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1361
16 AppKit                         0x7fff43c7b83c -[NSApplication run] + 699
17 Gureum                         0x10a5504ad main (<compiler-generated>)
18 libdyld.dylib                  0x7fff7252b3d5 start + 1

--

#0. Crashed: com.apple.main-thread
0  GureumCore                     0x10a6c145c $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptF + 5100
1  GureumCore                     0x10a6c16dc $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptFTo + 76
2  InputMethodKit                 0x10a7740a8 -[IMKServer handleEvent_Common:characterIndex:edge:clientWrapper:controller:] + 1350
3  InputMethodKit                 0x10a768fbd __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke_2 + 690
4  ViewBridge                     0x7fff6e09ff8e +[NSServiceViewController withHostProcessIdentifier:invoke:] + 41
5  InputMethodKit                 0x10a768d00 __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke + 143
6  InputMethodKit                 0x10a7757da __IMKXPCPerformBlockOnMainThread_block_invoke + 25
7  CoreFoundation                 0x7fff4663a164 __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
8  CoreFoundation                 0x7fff465fd887 __CFRunLoopDoBlocks + 394
9  CoreFoundation                 0x7fff465fd5e4 __CFRunLoopRun + 2772
10 CoreFoundation                 0x7fff465fc8be CFRunLoopRunSpecific + 455
11 HIToolbox                      0x7fff458e896b RunCurrentEventLoopInMode + 292
12 HIToolbox                      0x7fff458e86a5 ReceiveNextEventCommon + 603
13 HIToolbox                      0x7fff458e8436 _BlockUntilNextEventMatchingListInModeWithFilter + 64
14 AppKit                         0x7fff43c82987 _DPSNextEvent + 965
15 AppKit                         0x7fff43c8171f -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1361
16 AppKit                         0x7fff43c7b83c -[NSApplication run] + 699
17 Gureum                         0x10a5504ad main (<compiler-generated>)
18 libdyld.dylib                  0x7fff7252b3d5 start + 1

#1. Thread
0  libsystem_kernel.dylib         0x7fff72661bfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff7271e6e6 _pthread_wqthread + 634
2  libsystem_pthread.dylib        0x7fff7271e3fd start_wqthread + 13
3  (Missing)                      0x54485244 (Missing)

#2. Thread
0  libsystem_kernel.dylib         0x7fff72661bfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff7271e636 _pthread_wqthread + 458
2  libsystem_pthread.dylib        0x7fff7271e3fd start_wqthread + 13
3  (Missing)                      0x60000304de80 (Missing)

#3. io.answers.EventQueue (QOS: BACKGROUND)
0  libsystem_kernel.dylib         0x7fff72663f62 fsync + 10
1  Foundation                     0x7fff48886aaa _NSWriteDataToFileWithExtendedAttributes + 658
2  Gureum                         0x10a579432 +[ANSCrashMetadata writeSerializedDictionary:toURL:] + 125
3  Gureum                         0x10a57a3b6 -[ANSRotateCrashMetadataOperation main] + 597
4  Gureum                         0x10a586958 -[ANSAnswersController replacePreviousExecutionMetadataWithCurrentMetadata:inRootDirectory:] + 163
5  Gureum                         0x10a5858e2 __56-[ANSAnswersController initWithBetaToken:rootDirectory:]_block_invoke + 453
6  Foundation                     0x7fff4889a55c __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ + 7
7  Foundation                     0x7fff4889a464 -[NSBlockOperation main] + 68
8  Foundation                     0x7fff488701dd -[__NSOperationInternal _start:] + 685
9  Foundation                     0x7fff4889a197 __NSOQSchedule_f + 227
10 libdispatch.dylib              0x7fff724e9cea _dispatch_block_async_invoke2 + 83
11 libdispatch.dylib              0x7fff724de63d _dispatch_client_callout + 8
12 libdispatch.dylib              0x7fff724e0de6 _dispatch_continuation_pop + 414
13 libdispatch.dylib              0x7fff724e04a3 _dispatch_async_redirect_invoke + 703
14 libdispatch.dylib              0x7fff724ec3bc _dispatch_root_queue_drain + 324
15 libdispatch.dylib              0x7fff724ecb46 _dispatch_worker_thread2 + 90
16 libsystem_pthread.dylib        0x7fff7271e6b3 _pthread_wqthread + 583
17 libsystem_pthread.dylib        0x7fff7271e3fd start_wqthread + 13
18 (Missing)                      0x54485244 (Missing)

#4. Thread
0  libsystem_kernel.dylib         0x7fff72661bfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff7271e6e6 _pthread_wqthread + 634
2  libsystem_pthread.dylib        0x7fff7271e3fd start_wqthread + 13
3  (Missing)                      0x54485244 (Missing)

#5. com.twitter.crashlytics.mac.MachExceptionServer
0  Gureum                         0x10a56f8de CLSProcessRecordAllThreads + 193
1  Gureum                         0x10a56fcd9 CLSProcessRecordAllThreads + 1212
2  Gureum                         0x10a55f259 CLSHandler + 45
3  Gureum                         0x10a55a7a4 CLSMachExceptionServer + 1241
4  libsystem_pthread.dylib        0x7fff7271f2eb _pthread_body + 126
5  libsystem_pthread.dylib        0x7fff72722249 _pthread_start + 66
6  libsystem_pthread.dylib        0x7fff7271e40d thread_start + 13

#6. Thread
0  libsystem_kernel.dylib         0x7fff72661bfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff7271e6e6 _pthread_wqthread + 634
2  libsystem_pthread.dylib        0x7fff7271e3fd start_wqthread + 13
3  (Missing)                      0x54485244 (Missing)

#7. Thread
0  libsystem_kernel.dylib         0x7fff72661bfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff7271e636 _pthread_wqthread + 458
2  libsystem_pthread.dylib        0x7fff7271e3fd start_wqthread + 13
3  (Missing)                      0x7fffa18618e0 (Missing)

#8. Thread
0  libsystem_kernel.dylib         0x7fff72661bfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff7271e636 _pthread_wqthread + 458
2  libsystem_pthread.dylib        0x7fff7271e3fd start_wqthread + 13

#9. Thread
0  libsystem_kernel.dylib         0x7fff72661bfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff7271e636 _pthread_wqthread + 458
2  libsystem_pthread.dylib        0x7fff7271e3fd start_wqthread + 13

#10. Thread
0  libsystem_kernel.dylib         0x7fff72661bfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff7271e6e6 _pthread_wqthread + 634
2  libsystem_pthread.dylib        0x7fff7271e3fd start_wqthread + 13
3  (Missing)                      0x54485244 (Missing)

#11. com.apple.NSEventThread
0  libsystem_kernel.dylib         0x7fff7266022a mach_msg_trap + 10
1  libsystem_kernel.dylib         0x7fff7266076c mach_msg + 60
2  CoreFoundation                 0x7fff465fdbee __CFRunLoopServiceMachPort + 328
3  CoreFoundation                 0x7fff465fd15c __CFRunLoopRun + 1612
4  CoreFoundation                 0x7fff465fc8be CFRunLoopRunSpecific + 455
5  AppKit                         0x7fff43c8a6a6 _NSEventThread + 175
6  libsystem_pthread.dylib        0x7fff7271f2eb _pthread_body + 126
7  libsystem_pthread.dylib        0x7fff72722249 _pthread_start + 66
8  libsystem_pthread.dylib        0x7fff7271e40d thread_start + 13
```
</p></details>