### PR TITLE
Check if selectedRange is invalid in EmoticonComposer

### DIFF
--- a/OSXCore/EmoticonComposer.swift
+++ b/OSXCore/EmoticonComposer.swift
@@ -147,10 +147,10 @@ class EmoticonComposer: DelegatedComposer {
         let markedRange: NSRange = sender.markedRange()
         let selectedRange: NSRange = sender.selectedRange()
 
-        let isInvalidMarkedRange: Bool = markedRange.length == 0 || markedRange.length == NSNotFound
+        let isInvalidMarkedRange: Bool = markedRange.length == 0 || markedRange.location == NSNotFound
 
         dlog(DEBUG_EMOTICON, "DEBUG 2, [update] MSG: DEBUG POINT 1")
-        if isInvalidMarkedRange, selectedRange.length > 0 {
+        if isInvalidMarkedRange, selectedRange.location != NSNotFound, selectedRange.length > 0 {
             let selectedString: String = sender.attributedSubstring(from: selectedRange).string
 
             sender.setMarkedText(selectedString, selectionRange: selectedRange, replacementRange: selectedRange)


### PR DESCRIPTION
From Carbon.HIToolbox.IMKInputSession:
``` swift
/*!
    @method     
    @abstract   Returns the current selection range.
                
   @discussion If the client does not support the TSMDocumentAccess protocol the returned range will have a location value of NSNotFound and a length of NSNotFound.
              
               If a valid range is returned it is relative to the client's document.
*/
func selectedRange() -> NSRange
```

다음 이슈와 관련있을 수 있습니다.

<details>

```
# URL: https://fabric.io/youknowoneorg/mac/apps/org.youknowone.inputmethod.gureum/issues/5ce50649f8b88c2963945e12?time=1562112000000%3A1562198399000/sessions/a4282fb373f246ed95a32b929913f52c_DNE_0_v2
# Organization: youknowone.org
# Platform: mac_os_x
# Application: 구름 입력기
# Version: 1.10.0
# Bundle Identifier: org.youknowone.inputmethod.Gureum
# Issue ID: 5ce50649f8b88c2963945e12
# Session ID: a4282fb373f246ed95a32b929913f52c_DNE_0_v2
# Date: 2019-07-05T01:38:00Z
# OS Version: 10.14.5 (18F132)
# Device: MacBook Pro Retina, 15", Mid 2017
# RAM Free: < 1%
# Disk Free: 39.2%

#0. Crashed: com.apple.main-thread
0  GureumCore                     0x10fbf465b $s10GureumCore16EmoticonComposerC6update6clientySo12IMKTextInput_p_tF + 1643
1  GureumCore                     0x10fbf7867 $s10GureumCore0A8ComposerC12changeLayout_6clientAA11InputResultVAA06ChangeE0O_yptF + 2215
2  GureumCore                     0x10fbfcd19 $s10GureumCore13InputReceiverC5input5event6clientAA0C6ResultVAA0C5EventO_So07IMKTextC0_So014IMKUnicodeTextC0ptF + 105
3  GureumCore                     0x10fbfc341 $s10GureumCore13InputReceiverC5input4text3key9modifiers6clientAA0C6ResultVSSSg_SiSo20NSEventModifierFlagsVSo07IMKTextC0_So014IMKUnicodeTextC0ptF + 225
4  GureumCore                     0x10fbe8c3a $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptF + 2986
5  GureumCore                     0x10fbe968c $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptFTo + 76
6  InputMethodKit                 0x10fc980a8 -[IMKServer handleEvent_Common:characterIndex:edge:clientWrapper:controller:] + 1350
7  InputMethodKit                 0x10fc8cfbd __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke_2 + 690
8  ViewBridge                     0x7fff6cc13f8e +[NSServiceViewController withHostProcessIdentifier:invoke:] + 41
9  InputMethodKit                 0x10fc8cd00 __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke + 143
10 InputMethodKit                 0x10fc997da __IMKXPCPerformBlockOnMainThread_block_invoke + 25
11 CoreFoundation                 0x7fff451ae164 __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
12 CoreFoundation                 0x7fff45171887 __CFRunLoopDoBlocks + 394
13 CoreFoundation                 0x7fff451715e4 __CFRunLoopRun + 2772
14 CoreFoundation                 0x7fff451708be CFRunLoopRunSpecific + 455
15 HIToolbox                      0x7fff4445c96b RunCurrentEventLoopInMode + 292
16 HIToolbox                      0x7fff4445c6a5 ReceiveNextEventCommon + 603
17 HIToolbox                      0x7fff4445c436 _BlockUntilNextEventMatchingListInModeWithFilter + 64
18 AppKit                         0x7fff427f6987 _DPSNextEvent + 965
19 AppKit                         0x7fff427f571f -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1361
20 AppKit                         0x7fff427ef83c -[NSApplication run] + 699
21 Gureum                         0x10fa7954d main (<compiler-generated>)
22 libdyld.dylib                  0x7fff7109f3d5 start + 1

--

#0. Crashed: com.apple.main-thread
0  GureumCore                     0x10fbf465b $s10GureumCore16EmoticonComposerC6update6clientySo12IMKTextInput_p_tF + 1643
1  GureumCore                     0x10fbf7867 $s10GureumCore0A8ComposerC12changeLayout_6clientAA11InputResultVAA06ChangeE0O_yptF + 2215
2  GureumCore                     0x10fbfcd19 $s10GureumCore13InputReceiverC5input5event6clientAA0C6ResultVAA0C5EventO_So07IMKTextC0_So014IMKUnicodeTextC0ptF + 105
3  GureumCore                     0x10fbfc341 $s10GureumCore13InputReceiverC5input4text3key9modifiers6clientAA0C6ResultVSSSg_SiSo20NSEventModifierFlagsVSo07IMKTextC0_So014IMKUnicodeTextC0ptF + 225
4  GureumCore                     0x10fbe8c3a $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptF + 2986
5  GureumCore                     0x10fbe968c $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptFTo + 76
6  InputMethodKit                 0x10fc980a8 -[IMKServer handleEvent_Common:characterIndex:edge:clientWrapper:controller:] + 1350
7  InputMethodKit                 0x10fc8cfbd __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke_2 + 690
8  ViewBridge                     0x7fff6cc13f8e +[NSServiceViewController withHostProcessIdentifier:invoke:] + 41
9  InputMethodKit                 0x10fc8cd00 __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke + 143
10 InputMethodKit                 0x10fc997da __IMKXPCPerformBlockOnMainThread_block_invoke + 25
11 CoreFoundation                 0x7fff451ae164 __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
12 CoreFoundation                 0x7fff45171887 __CFRunLoopDoBlocks + 394
13 CoreFoundation                 0x7fff451715e4 __CFRunLoopRun + 2772
14 CoreFoundation                 0x7fff451708be CFRunLoopRunSpecific + 455
15 HIToolbox                      0x7fff4445c96b RunCurrentEventLoopInMode + 292
16 HIToolbox                      0x7fff4445c6a5 ReceiveNextEventCommon + 603
17 HIToolbox                      0x7fff4445c436 _BlockUntilNextEventMatchingListInModeWithFilter + 64
18 AppKit                         0x7fff427f6987 _DPSNextEvent + 965
19 AppKit                         0x7fff427f571f -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1361
20 AppKit                         0x7fff427ef83c -[NSApplication run] + 699
21 Gureum                         0x10fa7954d main (<compiler-generated>)
22 libdyld.dylib                  0x7fff7109f3d5 start + 1

#1. com.twitter.crashlytics.mac.MachExceptionServer
0  Gureum                         0x10fa9892e CLSProcessRecordAllThreads + 193
1  Gureum                         0x10fa98d29 CLSProcessRecordAllThreads + 1212
2  Gureum                         0x10fa882a9 CLSHandler + 45
3  Gureum                         0x10fa837f4 CLSMachExceptionServer + 1241
4  libsystem_pthread.dylib        0x7fff712932eb _pthread_body + 126
5  libsystem_pthread.dylib        0x7fff71296249 _pthread_start + 66
6  libsystem_pthread.dylib        0x7fff7129240d thread_start + 13

#2. com.apple.NSEventThread
0  libsystem_kernel.dylib         0x7fff711d422a mach_msg_trap + 10
1  libsystem_kernel.dylib         0x7fff711d476c mach_msg + 60
2  CoreFoundation                 0x7fff45171bee __CFRunLoopServiceMachPort + 328
3  CoreFoundation                 0x7fff4517115c __CFRunLoopRun + 1612
4  CoreFoundation                 0x7fff451708be CFRunLoopRunSpecific + 455
5  AppKit                         0x7fff427fe6a6 _NSEventThread + 175
6  libsystem_pthread.dylib        0x7fff712932eb _pthread_body + 126
7  libsystem_pthread.dylib        0x7fff71296249 _pthread_start + 66
8  libsystem_pthread.dylib        0x7fff7129240d thread_start + 13

#3. com.apple.NSURLConnectionLoader
0  libsystem_kernel.dylib         0x7fff711d422a mach_msg_trap + 10
1  libsystem_kernel.dylib         0x7fff711d476c mach_msg + 60
2  CoreFoundation                 0x7fff45171bee __CFRunLoopServiceMachPort + 328
3  CoreFoundation                 0x7fff4517115c __CFRunLoopRun + 1612
4  CoreFoundation                 0x7fff451708be CFRunLoopRunSpecific + 455
5  CFNetwork                      0x7fff440e4380 -[__CoreSchedulingSetRunnable runForever] + 210
6  Foundation                     0x7fff473ca6d2 __NSThread__start__ + 1194
7  libsystem_pthread.dylib        0x7fff712932eb _pthread_body + 126
8  libsystem_pthread.dylib        0x7fff71296249 _pthread_start + 66
9  libsystem_pthread.dylib        0x7fff7129240d thread_start + 13

#4. Thread
0  libsystem_kernel.dylib         0x7fff711d5bfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff712926e6 _pthread_wqthread + 634
2  libsystem_pthread.dylib        0x7fff712923fd start_wqthread + 13
3  (Missing)                      0x54485244 (Missing)

#5. Thread
0  libsystem_kernel.dylib         0x7fff711d5bfe __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff71292636 _pthread_wqthread + 458
2  libsystem_pthread.dylib        0x7fff712923fd start_wqthread + 13
3  (Missing)                      0x0 (Missing)
```
</details>