### PR TITLE
Check if selectedRange is invalid in HanjaComposer

### DIFF
--- a/OSXCore/HanjaComposer.swift
+++ b/OSXCore/HanjaComposer.swift
@@ -235,7 +235,7 @@ class HanjaComposer: DelegatedComposer {
         let markedRange: NSRange = client.markedRange()
         let selectedRange: NSRange = client.selectedRange()
         dlog(DEBUG_HANJACOMPOSER, "HanjaComposer -updateFromController: marked: %@ selected: %@", NSStringFromRange(markedRange), NSStringFromRange(selectedRange))
-        if markedRange.length == 0 || markedRange.length == NSNotFound, selectedRange.length > 0 {
+        if markedRange.length == 0 || markedRange.location == NSNotFound, selectedRange.location != NSNotFound, selectedRange.length > 0 {
             let selectedString = client.attributedSubstring(from: selectedRange).string
             dlog(DEBUG_HANJACOMPOSER, "HanjaComposer -updateFromController: selected string: %@", selectedString)
             client.setMarkedText(selectedString, selectionRange: selectedRange, replacementRange: selectedRange)


### PR DESCRIPTION
수정 내용은 #578 PR과 동일합니다.

다음 이슈와 관련있을 수 있습니다.

<details>

```
# URL: https://fabric.io/youknowoneorg/mac/apps/org.youknowone.inputmethod.gureum/issues/0339d4d488e39dcd257752991c21b7d4?time=last-thirty-days/sessions/8c37d5149f604ed8b8d12e00b63df46f_DNE_0_v2
# Organization: youknowone.org
# Platform: mac_os_x
# Application: 구름 입력기
# Version: 1.10.1-contrib
# Bundle Identifier: org.youknowone.inputmethod.Gureum
# Issue ID: 0339d4d488e39dcd257752991c21b7d4
# Session ID: 8c37d5149f604ed8b8d12e00b63df46f_DNE_0_v2
# Date: 2019-07-11T17:00:00Z
# OS Version: 10.13.6 (17G7024)
# Device: iMac 27", Mid 2011
# RAM Free: 8.8%
# Disk Free: 69.5%

#0. Crashed: com.apple.main-thread
0  GureumCore                     0x10a8f5b4e $s10GureumCore13HanjaComposerC6update6clientySo12IMKTextInput_p_tF
1  GureumCore                     0x10a8fd72e $s10GureumCore0A8ComposerC12changeLayout_6clientAA11InputResultVAA06ChangeE0O_yptF
2  GureumCore                     0x10a9031f9 $s10GureumCore13InputReceiverC5input5event6clientAA0C6ResultVAA0C5EventO_So07IMKTextC0_So014IMKUnicodeTextC0ptF
3  GureumCore                     0x10a902821 $s10GureumCore13InputReceiverC5input4text3key9modifiers6clientAA0C6ResultVSSSg_SiSo20NSEventModifierFlagsVSo07IMKTextC0_So014IMKUnicodeTextC0ptF
4  GureumCore                     0x10a8ef36b $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptF
5  GureumCore                     0x10a8efb9c $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptFTo
6  InputMethodKit                 0x10a98c8b0 -[IMKServer handleEvent_Common:characterIndex:edge:clientWrapper:controller:] + 1270
7  InputMethodKit                 0x10a980e3c __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke_2 + 690
8  InputMethodKit                 0x10a980b7f __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke + 149
9  InputMethodKit                 0x10a98dd87 __IMKXPCPerformBlockOnMainThread_block_invoke + 25
10 CoreFoundation                 0x7fff30f223dc __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
11 CoreFoundation                 0x7fff30f05313 __CFRunLoopDoBlocks + 275
12 CoreFoundation                 0x7fff30f050d8 __CFRunLoopRun + 3128
13 CoreFoundation                 0x7fff30f04207 CFRunLoopRunSpecific + 487
14 HIToolbox                      0x7fff301e4d96 RunCurrentEventLoopInMode + 286
15 HIToolbox                      0x7fff301e4b06 ReceiveNextEventCommon + 613
16 HIToolbox                      0x7fff301e4884 _BlockUntilNextEventMatchingListInModeWithFilter + 64
17 AppKit                         0x7fff2e494a73 _DPSNextEvent + 2085
18 AppKit                         0x7fff2ec2ae34 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 3044
19 AppKit                         0x7fff2e489885 -[NSApplication run] + 764
20 Gureum                         0x10a7834ad main (<compiler-generated>)
21 libdyld.dylib                  0x7fff58ec9015 start + 1

--

#0. Crashed: com.apple.main-thread
0  GureumCore                     0x10a8f5b4e $s10GureumCore13HanjaComposerC6update6clientySo12IMKTextInput_p_tF
1  GureumCore                     0x10a8fd72e $s10GureumCore0A8ComposerC12changeLayout_6clientAA11InputResultVAA06ChangeE0O_yptF
2  GureumCore                     0x10a9031f9 $s10GureumCore13InputReceiverC5input5event6clientAA0C6ResultVAA0C5EventO_So07IMKTextC0_So014IMKUnicodeTextC0ptF
3  GureumCore                     0x10a902821 $s10GureumCore13InputReceiverC5input4text3key9modifiers6clientAA0C6ResultVSSSg_SiSo20NSEventModifierFlagsVSo07IMKTextC0_So014IMKUnicodeTextC0ptF
4  GureumCore                     0x10a8ef36b $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptF
5  GureumCore                     0x10a8efb9c $s10GureumCore15InputControllerC6handle_6clientSbSo7NSEventC_yptFTo
6  InputMethodKit                 0x10a98c8b0 -[IMKServer handleEvent_Common:characterIndex:edge:clientWrapper:controller:] + 1270
7  InputMethodKit                 0x10a980e3c __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke_2 + 690
8  InputMethodKit                 0x10a980b7f __63-[IMKServer handleEvent:characterIndex:edge:asyncClient:reply:]_block_invoke + 149
9  InputMethodKit                 0x10a98dd87 __IMKXPCPerformBlockOnMainThread_block_invoke + 25
10 CoreFoundation                 0x7fff30f223dc __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
11 CoreFoundation                 0x7fff30f05313 __CFRunLoopDoBlocks + 275
12 CoreFoundation                 0x7fff30f050d8 __CFRunLoopRun + 3128
13 CoreFoundation                 0x7fff30f04207 CFRunLoopRunSpecific + 487
14 HIToolbox                      0x7fff301e4d96 RunCurrentEventLoopInMode + 286
15 HIToolbox                      0x7fff301e4b06 ReceiveNextEventCommon + 613
16 HIToolbox                      0x7fff301e4884 _BlockUntilNextEventMatchingListInModeWithFilter + 64
17 AppKit                         0x7fff2e494a73 _DPSNextEvent + 2085
18 AppKit                         0x7fff2ec2ae34 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 3044
19 AppKit                         0x7fff2e489885 -[NSApplication run] + 764
20 Gureum                         0x10a7834ad main (<compiler-generated>)
21 libdyld.dylib                  0x7fff58ec9015 start + 1

#1. com.twitter.crashlytics.mac.MachExceptionServer
0  Gureum                         0x10a7a28de CLSProcessRecordAllThreads
1  Gureum                         0x10a7a2cd9 CLSProcessRecordAllThreads
2  Gureum                         0x10a792259 CLSHandler
3  Gureum                         0x10a78d7a4 CLSMachExceptionServer
4  libsystem_pthread.dylib        0x7fff591e1661 _pthread_body + 340
5  libsystem_pthread.dylib        0x7fff591e150d _pthread_start + 375
6  libsystem_pthread.dylib        0x7fff591e0bf9 thread_start + 13

#2. com.apple.NSEventThread
0  libsystem_kernel.dylib         0x7fff5901020a mach_msg_trap + 10
1  libsystem_kernel.dylib         0x7fff5900f724 mach_msg + 60
2  CoreFoundation                 0x7fff30f05845 __CFRunLoopServiceMachPort + 341
3  CoreFoundation                 0x7fff30f04b97 __CFRunLoopRun + 1783
4  CoreFoundation                 0x7fff30f04207 CFRunLoopRunSpecific + 487
5  AppKit                         0x7fff2e5d1fc4 _NSEventThread + 184
6  libsystem_pthread.dylib        0x7fff591e1661 _pthread_body + 340
7  libsystem_pthread.dylib        0x7fff591e150d _pthread_start + 375
8  libsystem_pthread.dylib        0x7fff591e0bf9 thread_start + 13

#3. com.apple.NSURLConnectionLoader
0  libsystem_kernel.dylib         0x7fff5901020a mach_msg_trap + 10
1  libsystem_kernel.dylib         0x7fff5900f724 mach_msg + 60
2  CoreFoundation                 0x7fff30f05845 __CFRunLoopServiceMachPort + 341
3  CoreFoundation                 0x7fff30f04b97 __CFRunLoopRun + 1783
4  CoreFoundation                 0x7fff30f04207 CFRunLoopRunSpecific + 487
5  CFNetwork                      0x7fff30044778 -[__CoreSchedulingSetRunnable runForever] + 722
6  Foundation                     0x7fff3302b148 __NSThread__start__ + 1197
7  libsystem_pthread.dylib        0x7fff591e1661 _pthread_body + 340
8  libsystem_pthread.dylib        0x7fff591e150d _pthread_start + 375
9  libsystem_pthread.dylib        0x7fff591e0bf9 thread_start + 13

#4. Thread
0  libsystem_kernel.dylib         0x7fff5901a28a __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff591e1009 _pthread_wqthread + 1035
2  libsystem_pthread.dylib        0x7fff591e0be9 start_wqthread + 13
3  (Missing)                      0xf427e00004000 (Missing)

#5. Thread
0  libsystem_kernel.dylib         0x7fff5901a28a __workq_kernreturn + 10
1  libsystem_pthread.dylib        0x7fff591e120e _pthread_wqthread + 1552
2  libsystem_pthread.dylib        0x7fff591e0be9 start_wqthread + 13
```
</details>