### PR TITLE
한자 후보 화면 꾸미기 시도

### DIFF
--- a/OSXCore/HanjaComposer.swift
+++ b/OSXCore/HanjaComposer.swift
@@ -194,7 +194,7 @@ class HanjaComposer: DelegatedComposer {
         }
 
         // dlog(DEBUG_HANJACOMPOSER, "HanjaComposer -updateHanjaCandidates candidates")
-        var candidates: [String] = []
+        var candidates: [NSAttributedString] = []
         if keyword.count == 1 {
             for table in [HanjaComposer.msSymbolTable, HanjaComposer.characterTable] {
                 let tableCandidates = searchCandidates(fromTable: table, byPrefixSearching: keyword)
@@ -207,13 +207,13 @@ class HanjaComposer: DelegatedComposer {
         }
         dlog(DEBUG_HANJACOMPOSER, "HanjaComposer -updateHanjaCandidates candidating")
         if candidates.count > 0, Configuration.shared.showsInputForHanjaCandidates {
-            candidates.insert(keyword, at: 0)
+            candidates.insert(.init(string: keyword), at: 0)
         }
-        return candidates.map { s in NSAttributedString(string: s) }
+        return candidates
     }
 
-    func searchCandidates(fromTable table: HGHanjaTable, byPrefixSearching keyword: String) -> [String] {
-        var candidates: [String] = []
+    func searchCandidates(fromTable table: HGHanjaTable, byPrefixSearching keyword: String) -> [NSAttributedString] {
+        var candidates: [NSAttributedString] = []
         dlog(DEBUG_HANJACOMPOSER, "HanjaComposer -searchCandidates getting list for table: %@", table)
         guard let list: HGHanjaList = table.hanjas(byPrefixSearching: keyword) else {
             return candidates
@@ -222,9 +222,9 @@ class HanjaComposer: DelegatedComposer {
             let hanja = _hanja as! HGHanja
             dlog(DEBUG_HANJACOMPOSER, "HanjaComposer -searchCandidates hanja: %@", hanja)
             if hanja.comment.isEmpty {
-                candidates.append("\(hanja.value)")
+                candidates.append(.init(string: hanja.value))
             } else {
-                candidates.append("\(hanja.value): \(hanja.comment)")
+                candidates.append(.init(string: "\(hanja.value) \(hanja.comment)", attributes: [.foregroundColor: NSColor.red]))
             }
         }
         return candidates

--- a/OSXCore/InputMethodServer.swift
+++ b/OSXCore/InputMethodServer.swift
@@ -163,6 +163,7 @@ public class InputMethodServer {
 
         server = IMKServer(name: name, bundleIdentifier: Bundle.main.bundleIdentifier)
         candidates = IMKCandidates(server: server, panelType: kIMKSingleColumnScrollingCandidatePanel)
+        candidates.setAttributes([NSAttributedString.Key.foregroundColor: NSColor.red])
         // candidates.setSelectionKeysKeylayout(TISInputSource.currentKeyboardLayout())
 
         io = IOKitty()!


### PR DESCRIPTION
#597

1. `IMKCandidates`의 `setAttributes(_:)` 메소드 사용
2. 한자 후보를 build하는 메소드가 리턴하는 `NSAttributedString`에 attribute 추가
---
결과 : 적용되지 않음