### PR TITLE
긴한자 검색 오류 해결

### DIFF
--- a/OSXCore/InputReceiver.swift
+++ b/OSXCore/InputReceiver.swift
@@ -100,6 +100,9 @@ public class InputReceiver: InputTextDelegate {
         let hadComposedString = !_internalComposedString.isEmpty
         let result = input2(text: string, key: keyCode, modifiers: flags, client: sender)
 
+        // 합성 후보가 있다면 보여준다
+        InputMethodServer.shared.showOrHideCandidates(controller: controller)
+        
         inputting = true
 
         if result.action != .none {


### PR DESCRIPTION
- Fix #603 

- `#586` 커밋에서 `showOrHideCandidates()` 를 호출하는 부분이 삭제되어 정상 동작하지 않았었습니다. 다시 추가하였습니다.