### PR TITLE
Handle return key to select current candidate

### DIFF
--- a/OSXCore/InputController.swift
+++ b/OSXCore/InputController.swift
@@ -114,7 +114,7 @@ public extension InputController { // IMKServerInputHandleEvent
         let imkCandidates = InputMethodServer.shared.candidates
         if imkCandidates.isVisible() {
             let selectionKeys = imkCandidates.selectionKeys() as? [NSNumber] ?? []
-            if KeyCode.arrows.contains(keyCode) || selectionKeys.contains(NSNumber(value: event.keyCode)) {
+            if KeyCode.arrows.contains(keyCode) || keyCode == .return || selectionKeys.contains(NSNumber(value: event.keyCode)) {
                 imkCandidates.interpretKeyEvents([event])
                 return true
             }


### PR DESCRIPTION
테스트 하려면 `InputController.handle(_:client:)` 관련해서 추가해야 할 것 같은데, 그것만으로 `selectCandidate`를 호출하게 할 수 있을지는 모르겠습니다.