### PR TITLE
Clean up README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,28 @@
 [![Build Status](https://travis-ci.org/gureum/gureum.svg?branch=master)](https://travis-ci.org/gureum/gureum)
 
-## 소개
+# 구름 입력기
+
 구름 입력기는 libhangul 기반의 작고 가벼운 한글 입력기입니다.
 
-# 장점
+## 장점
+
 구름 한글 입력기는 libhangul을 기반으로 만들어져 두벌식, 세벌식, 로마자 자판 등 다양한 자판을 지원하고 특히 모아쓰기 기능이 제공됩니다.
 
 한편으로는 libhangul 이외의 기능을 거의 사용하지 않아 가볍게 돌아갑니다.
 
 또 입력기 전환을 막기 위하여 쿼티 자판을 추가로 내장하고 있어 한글-쿼티 전환이 빠릅니다. 일부 환경에서 자판 전환이 느릴때 도움이 됩니다.
 
-# 설치
+## 설치
+
 1. [다운로드 페이지](http://bi.gureum.org)에서 가장 높은 버전의 GureumKIM1.x.pkg를 다운받아 실행하고 지시대로 설치합니다. 설치 할 디스크는 바꾸시면 안됩니다.
-  - brew 사용자라면 `brew cask install gureumkim` 명령으로도 설치할 수 있습니다.
-1. 시스템 환경설정 -> 언어 & 텍스트 -> 입력 소스 에 들어가 구름 입력기를 선택합니다.
- * 여기서 입력기가 나타나지 않으면 설치 패키지가 입력기를 올바르게 설치하지 못한 것입니다. 다음 방법으로 수동으로 설치합니다.
-   1. 위 다운로드 페이지에서 가장 높은 버전의 GureumKIM1.x.zip을 다운받아 압축을 해제합니다.
-   1. GureumKIM.app을 `/Library/Input Methods`에 복사합니다. (Finder에서 루트 디스크 선택 -> 라이브러리 -> Input Methods)
-   1. 로그아웃 후 다시 로그인하여 입력 소스에서 구름 입력기를 선택합니다.
+   - Homebrew 사용자라면 `brew cask install gureumkim` 명령으로도 설치할 수 있습니다.
+1. 시스템 환경설정 → 키보드 → 입력 소스에 들어가 구름 입력기를 선택합니다.
+   - 여기서 입력기가 나타나지 않으면 설치 패키지가 입력기를 올바르게 설치하지 못한 것입니다. 다음 방법으로 수동으로 설치합니다.
+     1. 위 다운로드 페이지에서 가장 높은 버전의 GureumKIM1.x.zip을 다운받아 압축을 해제합니다.
+     1. GureumKIM.app을 `/Library/Input Methods`에 복사합니다. (Finder에서 루트 디스크 선택 → 라이브러리 → Input Methods)
+     1. 로그아웃 후 다시 로그인하여 입력 소스에서 구름 입력기를 선택합니다.
 1. 오른쪽 위 막대에 입력 소스에서 구름 입력기를 선택할 수 있습니다.
-1. 주 한글 자판을 선택하기 위해 사용할 한글 자판을 수동으로 한번 선택해 줍니다. 다음부터는 Shift+Space 로 자동으로 선택한 자판으로 이동합니다.
+1. 주 한글 자판을 선택하기 위해 사용할 한글 자판을 수동으로 한번 선택해 줍니다. 다음부터는 <kbd>Shift</kbd>+<kbd>Space</kbd>로 자동으로 선택한 자판으로 이동합니다.
 
 ## 제거
 
@@ -30,11 +33,11 @@
 1. `터미널.app (Terminal.app)`을 실행합니다.
 2. 다음의 명령을 터미널에 입력하고 Enter 키를 눌러 명령을 실행합니다. 패스워드를 요구한다면 패스워드를 입력해 줍니다.
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/gureum/gureum/master/tools/uninstall.sh | bash
-```
+   ```sh
+   curl -fsSL https://raw.githubusercontent.com/gureum/gureum/master/tools/uninstall.sh | bash
+   ```
 
-> brew로 설치한 경우 `brew cask uninstall gureumkim` 명령으로 삭제할 수 있습니다.
+Homebrew로 설치한 경우 `brew cask uninstall gureumkim` 명령으로 삭제할 수 있습니다.
 
 ### 수동 삭제
 
@@ -43,11 +46,12 @@ curl -fsSL https://raw.githubusercontent.com/gureum/gureum/master/tools/uninstal
 2. Finder에서 `/Library/Input Methods` 경로로 이동하여 `Gureum.app`을 삭제합니다.
 
 ## 개발 환경 설정
+
 구름 입력기의 개발 환경을 설정하고 디버깅 할 수 있는 방법을 제공합니다. [개발 환경 설정법](https://github.com/gureum/gureum/blob/master/HACKING.md)
 
-# 버그 신고
-입력기 사용 중 문제가 있으면 어떤 문제가 있나 알려주시면 도움이 됩니다. 버그가 재현되는지 확인해 주시고 [이슈 페이지](https://github.com/gureum/gureum/issues)에 사용 환경과 버그를 재현하는 방법을 알려주시면 고치도록 노력하겠습니다.
+## 버그 신고
 
+입력기 사용 중 문제가 있으면 어떤 문제가 있나 알려주시면 도움이 됩니다. 버그가 재현되는지 확인해 주시고 [이슈 페이지](https://github.com/gureum/gureum/issues)에 사용 환경과 버그를 재현하는 방법을 알려주시면 고치도록 노력하겠습니다.
 
 ## 만든 사람들
 


### PR DESCRIPTION
<https://github.com/gureum/gureum/pull/624#discussion_r326994046>의 연장입니다. 미리보기는 [여기](https://github.com/yous/gureum/blob/9c0ec9200c6269c70979df14108631280ec61e1d/README.md)에서 가능합니다.

- 맨 위의 제목만 H1, 나머지는 H2부터 시작
- 제목 바로 뒤 공백 한 줄
- 들여쓰기 인식 안 된 목록 수정
- 목록에 포함된 코드 들여쓰기
- brew → Homebrew
- `->` → `→`
- 환경설정 항목 macOS 10.14에 맞게 업데이트
- `<kbd>` 사용