### PR TITLE
Add Makefile for swiftformat

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,5 +1,11 @@
 # 개발환경 설정
 
+구름 입력기는 CocoaPods으로 의존성을 관리합니다. Xcode를 사용해 개발하기 전에 CocoaPods을 설치해야 합니다.
+
+``` sh
+sudo gem install cocoapods
+```
+
 libhangul의 라이선스 전파성을 피하기 위해 프로젝트를 분리하여 준비가 조금 복잡합니다.
 git submodule을 포함하고 있으므로 클론 후 submodule도 가져오도록 해야합니다.
 
@@ -32,7 +38,7 @@ git submodule update --init --recursive
 
 ![image](https://user-images.githubusercontent.com/906974/48977284-c5fc8e80-f0da-11e8-9ad2-7a40b8e774ea.png)
 
-Debug Configuration으로 빌드하면 Console.app 에서 로그를 확인할 수 있습니다.
+Debug Configuration으로 빌드하면 Console.app에서 로그를 확인할 수 있습니다.
 
 # 디버그 빌드 테스트
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -103,7 +103,5 @@ sudo gem install xcpretty
 변경한 소스 코드에 대해 swiftformat을 실행하여 코드의 일관성을 유지해 주세요. CI 과정에서 swiftformat으로 인한 변경 사항이 발견되면 빌드는 통과되지 않습니다.
 
 ```sh
-# 예시
-swiftformat OSXCore/
+make format
 ```
-

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+all:
+	@echo 'Available commands:'
+	@echo '    format: format code style with swiftformat'
+
+format:
+	swiftformat OSXCore/ OSX/ GureumTests/ Preferences/ OSXTestApp/


### PR DESCRIPTION
여기에 `make init`도 추가할까 생각해봤습니다. (#635)
``` makefile
init:
	git submodule update --init --recursive
	pod install
```
`tools/Makefile`이 있어 그걸 수정할까도 생각해봤는데, 아무래도 `build_product.sh`나 `test_product.sh`는 주로 릴리스 용도로 쓸 것 같아 그냥 뒀습니다.