### PR TITLE
Enable pipefail to detect failure of pipeline

### DIFF
--- a/tools/build_product.sh
+++ b/tools/build_product.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #https://discuss.atom.io/t/sandbox-supposedly-enabled-but-application-loader-disagrees/26155
+set -o pipefail
 
 if [ ! "${CONFIGURATION}" ]; then
     CONFIGURATION='Release'

--- a/tools/install_debug.sh
+++ b/tools/install_debug.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o pipefail
 
 run_with_echo() {
     echo "$@" && eval "$@" || exit $?
@@ -14,7 +15,7 @@ else
     PRINTER="cat"
 fi
 
-(xcodebuild -workspace 'Gureum.xcworkspace' -scheme 'OSX' -configuration "${CONFIGURATION}" | $PRINTER ) || exit $?
+(xcodebuild -workspace 'Gureum.xcworkspace' -scheme 'OSX' -configuration "${CONFIGURATION}" | $PRINTER) || exit $?
 if [ ! "${INSTALL_PATH}" ]; then
     echo "something wrong" && exit 255
 fi

--- a/tools/ready.sh
+++ b/tools/ready.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
 cd "${SCRIPT_DIR}/.." || exit $?
@@ -16,7 +17,7 @@ fi
 
 echo "Configuration: ${CONFIGURATION}"
 
-xcodebuild -workspace 'Gureum.xcworkspace' -scheme 'ScriptSupport' -configuration "${CONFIGURATION}" | grep export > "${TMPSCRIPT}"
+(xcodebuild -workspace 'Gureum.xcworkspace' -scheme 'ScriptSupport' -configuration "${CONFIGURATION}" | grep export > "${TMPSCRIPT}") || exit $?
 # shellcheck disable=1090
 . "${TMPSCRIPT}" > /dev/null 2>&1
 rm "${TMPSCRIPT}"


### PR DESCRIPTION
`(xcodebuild ... | $PRINTER) || exit $?`과 같은 코드에서 `xcodebuild` 명령이 실패한 경우에도 `(...)` 자체의 exit code는 `$PRINTER`의 exit code만을 반영하기 때문에 `exit $?`이 실행되지 않습니다. `set -o pipefail`을 켜면 `xcodebuild ... | $PRINTER` 파이프라인의 하나라도 exit code가 0이 아닌 경우에 그 exit code로 전달되게 됩니다.

- https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/#set-o-pipefail

간단하게 빌드를 실패시키는 방법으로는 `gem install cocoapods --version 1.8.3` 등으로 현재 Podfile.lock에 지정된 CocoaPods 버전과 다른 버전을 설치, `pod install`을 하지 않은 채 빌드를 시도해보면 됩니다. 다른 버전 삭제는 `gem uninstall cocoapods --version 1.8.3` 등으로 하면 됩니다.