### PR TITLE
Fix bug when updating candidates asynchronously

### DIFF
--- a/OSXCore/InputMethodServer.swift
+++ b/OSXCore/InputMethodServer.swift
@@ -207,7 +207,11 @@ public class InputMethodServer {
     }
 
     func showOrHideCandidates(controller: InputController) {
-        if controller.receiver.composer.hasCandidates {
+        showOrHideCandidates(composer: controller.receiver.composer)
+    }
+
+    func showOrHideCandidates(composer: Composer) {
+        if composer.hasCandidates {
             candidates.update()
             candidates.show(kIMKLocateCandidatesLeftHint)
         } else if candidates.isVisible() {


### PR DESCRIPTION
This is a follow-up of #671.

`InputMethodServer`의 `showOrHideCandidates`를 `composer`도 받을 수 있게 고쳤는데, 아예 함수를 바꿀 수도 있겠네요.

`var workItem`은 안쪽에서 `isCancelled` 검사하기 위함이고, `candidates`가 `nil`일 때와 아닐 때의 `showOrHideCandidates`의 동작이 다르기 때문에 candidates 업데이트와 `showOrHideCandidates`가 웬만하면 동시에 이뤄지도록 lock 사용했습니다.