### PR TITLE
Fix AppleScript opening keyboard preference

### DIFF
--- a/Preferences/PreferenceViewController.swift
+++ b/Preferences/PreferenceViewController.swift
@@ -94,7 +94,12 @@ final class PreferenceViewController: NSViewController {
     // MARK: IBAction
 
     @IBAction private func openKeyboardPreference(sender _: NSControl) {
-        let myAppleScript = "reveal anchor \"ShortcutsTab\" of pane id \"com.apple.preference.keyboard\""
+        let myAppleScript = [
+            "tell application \"System Preferences\"",
+            "\tactivate",
+            "\treveal anchor \"ShortcutsTab\" of pane id \"com.apple.preference.keyboard\"",
+            "end tell",
+        ].joined(separator: "\n")
         var error: NSDictionary?
         if let scriptObject = NSAppleScript(source: myAppleScript) {
             let output: NSAppleEventDescriptor = scriptObject.executeAndReturnError(


### PR DESCRIPTION
Catalina에서부터 그러는 건지는 모르겠는데, 이것으로 동작하는 것 확인했고, 아마 이전 버전과도 문제 없을 것으로 보입니다.

참고: https://www.macosxautomation.com/applescript/features/system-prefs.html