### PR TITLE
Add only han2 and system keyboards by default

### DIFF
--- a/OSX/Info.plist
+++ b/OSX/Info.plist
@@ -56,7 +56,7 @@
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>eng.png</string>
 				<key>tsInputModeDefaultStateKey</key>
-				<true/>
+				<false/>
 				<key>tsInputModeIsVisibleKey</key>
 				<true/>
 				<key>tsInputModeMenuIconFileKey</key>
@@ -77,7 +77,7 @@
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>eng.png</string>
 				<key>tsInputModeDefaultStateKey</key>
-				<true/>
+				<false/>
 				<key>tsInputModeIsVisibleKey</key>
 				<true/>
 				<key>tsInputModeMenuIconFileKey</key>
@@ -360,7 +360,7 @@
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>qwerty.png</string>
 				<key>tsInputModeDefaultStateKey</key>
-				<true/>
+				<false/>
 				<key>tsInputModeIsVisibleKey</key>
 				<true/>
 				<key>tsInputModeMenuIconFileKey</key>


### PR DESCRIPTION
`tsInputModeDefaultStateKey`와 `tsInputModePrimaryInScriptKey`의 정확한 차이는 모르겠으나 지금 구름 입력기를 설치하면 두벌식, 쿼티, 시스템, 콜맥, 드보락 키보드가 모두 추가되어서 번거로운 것 같습니다. 두벌식과 쿼티를 제외한 나머지 키보드는 자동으로 추가되지 않도록 했습니다.