### PR TITLE
한자/이모지 리팩터링 & 버그 수정

### DIFF
--- a/GureumTests/GureumTests.swift
+++ b/GureumTests/GureumTests.swift
@@ -505,8 +505,8 @@ class GureumTests: XCTestCase {
             app.controller.setValue(GureumInputSource.qwerty.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
 
             let composer = app.controller.receiver.composer
-            let emoticonComposer = composer.romanDependentSearchComposer
-            emoticonComposer.delegate = composer.delegate // roman?
+            let emoticonComposer = composer.searchComposer
+            emoticonComposer.delegate = composer.delegate
             composer.delegate = emoticonComposer
 
             app.inputKey(.ansiS)

--- a/OSXCore/GureumComposer.swift
+++ b/OSXCore/GureumComposer.swift
@@ -202,14 +202,16 @@ extension GureumComposer {
             return .changeLayout(.search, true)
         }
 
-        if let searchingComposer = delegate as? SearchComposer {
-            if searchingComposer.delegate is HangulComposer, !searchingComposer.showsCandidateWindow, searchingComposer.composedString.isEmpty, searchingComposer.commitString.isEmpty {
+        if let searchComposer = delegate as? SearchComposer {
+            if searchComposer.delegate is HangulComposer, !searchComposer.showsCandidateWindow, searchComposer.composedString.isEmpty, searchComposer.commitString.isEmpty {
                 // 한자 입력이 완료되었고 한자 모드도 아님
                 delegate = hangulComposer
-            } else if searchingComposer.delegate is RomanComposer {
-                if !searchingComposer.showsCandidateWindow {
-                    searchingComposer.showsCandidateWindow = true
+                searchComposer.delegate = nil
+            } else if searchComposer.delegate is RomanComposer {
+                if !searchComposer.showsCandidateWindow {
+                    searchComposer.showsCandidateWindow = true
                     delegate = romanComposer
+                    searchComposer.delegate = nil
                 }
             }
         }

--- a/OSXCore/HangulComposer.swift
+++ b/OSXCore/HangulComposer.swift
@@ -153,8 +153,7 @@ final class HangulComposer: NSObject, Composer {
     }
 
     func clear() {
-        inputContext.reset()
-        _commitString = ""
+        clearCompositionContext()
     }
 
     @discardableResult

--- a/OSXCore/SearchComposer.swift
+++ b/OSXCore/SearchComposer.swift
@@ -64,10 +64,6 @@ final class SearchComposer: Composer {
 
     var showsCandidateWindow = true
 
-    // MARK: 이모지 전용 프로퍼티
-
-    private var _selectedCandidate: NSAttributedString?
-
     // MARK: Composer 프로토콜 구현
 
     public var delegate: Composer!
@@ -119,17 +115,8 @@ final class SearchComposer: Composer {
         updateCandidates()
     }
 
-    func candidateSelectionChanged(_ candidateString: NSAttributedString) {
-        if candidateString.length == 0 {
-            _selectedCandidate = nil
-        } else {
-            let components = candidateString.string.components(separatedBy: ":")
-            guard components.count >= 2 else {
-                return
-            }
-            let candidate = components.first!
-            _selectedCandidate = NSAttributedString(string: candidate)
-        }
+    func candidateSelectionChanged(_: NSAttributedString) {
+        // nothing to do
     }
 
     func updateCandidates() {
@@ -189,7 +176,7 @@ final class SearchComposer: Composer {
             exitComposer()
             return InputResult(processed: false, action: .commit)
         case .return:
-            candidateSelected(_selectedCandidate ?? NSAttributedString(string: composedString))
+            return InputResult(processed: false, action: .candidatesEvent(keyCode))
         default:
             if searchSource == .roman {
                 if result == .notProcessed, let text = text, keyCode.isKeyMappable {

--- a/OSXCore/SearchComposer.swift
+++ b/OSXCore/SearchComposer.swift
@@ -28,19 +28,34 @@ extension HGHanjaList: Sequence {
 /// 한자 및 이모지 합성기의 동작을 구현한다.
 final class SearchComposer: Composer {
     /// 문자를 검색하여 입력하는 합성기가 의존하는 합성기의 종류를 정의한 열거형.
-    enum DependentComposerType {
+    enum SearchSource {
+        case unknown
         case hangul
         case roman
     }
 
-    private let _dependentComposerType: SearchComposer.DependentComposerType
-
     // MARK: 공통 프로퍼티
 
-    private var _candidates: [NSAttributedString]?
+    init() {}
+
+    // 검색할 소스
+    var searchSource: SearchComposer.SearchSource {
+        guard let delegate = delegate else {
+            return .unknown
+        }
+        if delegate is HangulComposer {
+            return .hangul
+        }
+        if delegate is RomanComposer {
+            return .roman
+        }
+        assert(false)
+    }
+
+    public private(set) var candidates: [NSAttributedString]?
     private var _bufferedString = ""
-    private var _composedString = ""
-    private var _commitString = ""
+    public private(set) var composedString = ""
+    public private(set) var commitString = ""
 
     // 검색을 위한 백그라운드 스레드
     private var _searchWorkItem: DispatchWorkItem = DispatchWorkItem {}
@@ -53,52 +68,24 @@ final class SearchComposer: Composer {
 
     private var _selectedCandidate: NSAttributedString?
 
-    /// 오브젝트가 의존하는 합성기의 종류.
-    ///
-    /// 한자 합성은 한글 합성기에 의존하고, 이모지 합성은 한글 및 로마자 합성기에 의존한다.
-    var dependentComposerType: SearchComposer.DependentComposerType {
-        return _dependentComposerType
-    }
-
-    init(dependentComposerType: SearchComposer.DependentComposerType) {
-        _dependentComposerType = dependentComposerType
-    }
-
     // MARK: Composer 프로토콜 구현
 
-    var delegate: Composer!
-
-    var composedString: String {
-        return _composedString
-    }
+    public var delegate: Composer!
 
     // 한자 합성의 경우 현재 진행 중인 조합 + 한글 입력기가 지금까지 완료한 조합.
     var originalString: String {
-        switch dependentComposerType {
-        case .hangul:
-            return _bufferedString + delegate.composedString
-        case .roman:
-            return _bufferedString
-        }
-    }
-
-    var commitString: String {
-        return _commitString
-    }
-
-    var candidates: [NSAttributedString]? {
-        return _candidates
+        _bufferedString + delegate.composedString
     }
 
     var hasCandidates: Bool {
-        return !(candidates?.isEmpty ?? true)
+        !(candidates?.isEmpty ?? true)
     }
 
     func dequeueCommitString() -> String {
-        let result = _commitString
+        let result = commitString
         if !result.isEmpty {
             _bufferedString = ""
-            _commitString = ""
+            commitString = ""
         }
         return result
     }
@@ -106,27 +93,26 @@ final class SearchComposer: Composer {
     func cancelComposition() {
         delegate.cancelComposition()
         delegate.dequeueCommitString()
-        _commitString.append(_composedString)
+        commitString.append(composedString)
         _bufferedString = ""
-        _composedString = ""
+        composedString = ""
     }
 
     func clearCompositionContext() {
-        switch dependentComposerType {
-        case .hangul:
-            delegate.clearCompositionContext()
-        case .roman:
-            _commitString = ""
-        }
+        delegate?.clearCompositionContext()
     }
 
     func candidateSelected(_ candidateString: NSAttributedString) {
         dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 1, DelegatedComposer.candidateSelected(_:) function called")
-        guard let word = candidateString.string.components(separatedBy: ":").first else { return }
-        dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 2, DelegatedComposer.candidateSelected(_:) value == %@", word)
+        let components = candidateString.string.components(separatedBy: ":")
+        guard components.count >= 2 else {
+            return
+        }
+        let candidate = components.first!
+        dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 2, DelegatedComposer.candidateSelected(_:) value == %@", candidate)
         _bufferedString = ""
-        _composedString = ""
-        _commitString = word
+        composedString = ""
+        commitString = candidate
         delegate.cancelComposition()
         delegate.dequeueCommitString()
 
@@ -134,22 +120,27 @@ final class SearchComposer: Composer {
     }
 
     func candidateSelectionChanged(_ candidateString: NSAttributedString) {
-        if dependentComposerType == .roman {
-            if candidateString.length == 0 {
-                _selectedCandidate = nil
-            } else {
-                guard let emoji = candidateString.string.components(separatedBy: ":").first else { return }
-                _selectedCandidate = NSAttributedString(string: emoji)
+        if candidateString.length == 0 {
+            _selectedCandidate = nil
+        } else {
+            let components = candidateString.string.components(separatedBy: ":")
+            guard components.count >= 2 else {
+                return
             }
+            let candidate = components.first!
+            _selectedCandidate = NSAttributedString(string: candidate)
         }
     }
 
     func updateCandidates() {
-        switch dependentComposerType {
+        switch searchSource {
         case .hangul:
             updateHanjaCandidates()
         case .roman:
             updateEmojiCandidates()
+        case .unknown:
+            // TODO: both
+            break
         }
     }
 
@@ -157,14 +148,12 @@ final class SearchComposer: Composer {
                key keyCode: KeyCode,
                modifiers flags: NSEvent.ModifierFlags,
                client sender: IMKTextInput & IMKUnicodeTextInput) -> InputResult {
-        // 한자의 경우 위아래 화살표에 대한 처리 선행
-        if dependentComposerType == .hangul {
-            switch keyCode {
-            case .upArrow, .downArrow:
-                return InputResult(processed: false, action: .candidatesEvent(keyCode))
-            default:
-                break
-            }
+        // 위아래 화살표에 대한 처리 선행
+        switch keyCode {
+        case .upArrow, .downArrow:
+            return InputResult(processed: false, action: .candidatesEvent(keyCode))
+        default:
+            break
         }
 
         var result = delegate.input(text: text, key: keyCode, modifiers: flags, client: sender)
@@ -177,14 +166,14 @@ final class SearchComposer: Composer {
                     dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 1, DelegateComposer.input(text:key:modifiers:client:) before (%@)", _bufferedString)
                     _bufferedString.removeLast()
                     dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 2, DelegateComposer.input(text:key:modifiers:client:) after (%@)", _bufferedString)
-                    _composedString = originalString
+                    composedString = originalString
                     result = .processed
                 } else {
                     showsCandidateWindow = false
                 }
             }
         case .space:
-            if dependentComposerType == .hangul {
+            if searchSource == .hangul {
                 // 강제로 조합 중인 문자 추출
                 delegate.cancelComposition()
                 _bufferedString.append(delegate.dequeueCommitString())
@@ -200,11 +189,9 @@ final class SearchComposer: Composer {
             exitComposer()
             return InputResult(processed: false, action: .commit)
         case .return:
-            if dependentComposerType == .roman {
-                candidateSelected(_selectedCandidate ?? NSAttributedString(string: composedString))
-            }
+            candidateSelected(_selectedCandidate ?? NSAttributedString(string: composedString))
         default:
-            if dependentComposerType == .roman {
+            if searchSource == .roman {
                 if result == .notProcessed, let text = text, keyCode.isKeyMappable {
                     _bufferedString.append(text)
                     result = .processed
@@ -245,7 +232,7 @@ extension SearchComposer {
                  NSStringFromRange(sender.selectedRange()))
             _bufferedString = selectedString
             dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 4, DelegatedComposer.update(client:) %@", _bufferedString)
-            if dependentComposerType == .hangul {
+            if searchSource == .hangul {
                 showsCandidateWindow = false
             }
         }
@@ -262,13 +249,13 @@ extension SearchComposer {
             _searchWorkItem.cancel()
         }
         _searchLock.lock()
-        _candidates = nil
+        candidates = nil
         _searchLock.unlock()
         // 3. 조합 중인 문자를 모두 가져옴
         delegate.cancelComposition()
         _bufferedString.append(delegate.dequeueCommitString())
         // 4. 그대로 커밋
-        _composedString = originalString
+        composedString = originalString
         cancelComposition()
     }
 }
@@ -278,7 +265,8 @@ extension SearchComposer {
 private extension SearchComposer {
     /// 한자 입력을 위한 후보를 만든다.
     func updateHanjaCandidates() {
-        assert(dependentComposerType == .hangul)
+        assert(delegate != nil)
+        assert(searchSource == .hangul)
 
         dlog(DEBUG_SEARCH_COMPOSER, "SearchComposer.updateHanjaCandidates()")
         // step 1: 한글 입력기에서 조합 완료된 글자를 가져옴
@@ -287,7 +275,7 @@ private extension SearchComposer {
         _bufferedString.append(hangulString)
         // step 2: 일단 화면에 한글이 표시되도록 조정
         dlog(DEBUG_SEARCH_COMPOSER, "SearchComposer.updateHanjaCandidates() step2")
-        _composedString = originalString
+        composedString = originalString
         // step 3: 키가 없거나 검색 결과가 키 prefix와 일치하지 않으면 후보를 보여주지 않는다.
         dlog(DEBUG_SEARCH_COMPOSER, "SearchComposer.updateHanjaCandidates() step3")
 
@@ -295,12 +283,12 @@ private extension SearchComposer {
         if !_searchWorkItem.isCancelled {
             _searchWorkItem.cancel()
         }
-        _candidates = [NSAttributedString(string: "검색 중...")] // default candidates
+        candidates = [NSAttributedString(string: "검색 중...")] // default candidates
 
         guard !keyword.isEmpty else {
             dlog(DEBUG_SEARCH_COMPOSER, "SearchComposer.updateHanjaCandidates() has no keywords")
             _searchLock.lock()
-            _candidates = nil
+            candidates = nil
             _searchLock.unlock()
             return
         }
@@ -316,18 +304,17 @@ private extension SearchComposer {
             guard !workItem.isCancelled else { return }
 
             self._searchLock.lock()
-            self._candidates = newCandidates
+            self.candidates = newCandidates
             if workItem.isCancelled {
                 self._searchLock.unlock()
                 return
             }
             DispatchQueue.main.async {
-                if workItem.isCancelled {
-                    self._searchLock.unlock()
+                defer { self._searchLock.unlock() }
+                guard !workItem.isCancelled else {
                     return
                 }
                 InputMethodServer.shared.showOrHideCandidates(composer: self)
-                self._searchLock.unlock()
             }
         }
         _searchWorkItem = workItem
@@ -339,7 +326,7 @@ private extension SearchComposer {
 
 private extension SearchComposer {
     func updateEmojiCandidates() {
-        assert(dependentComposerType == .roman)
+        assert(searchSource == .roman)
 
         // Step 1: 의존 합성기로부터 문자열 가져오기
         let dequeued = delegate.dequeueCommitString()
@@ -347,14 +334,14 @@ private extension SearchComposer {
         _bufferedString.append(dequeued)
         _bufferedString.append(delegate.composedString)
         let originalString = _bufferedString
-        _composedString = originalString
+        composedString = originalString
         let keyword = originalString
 
-        dlog(DEBUG_SEARCH_COMPOSER, "Candidates before search, %@", _candidates ?? "nil")
+        dlog(DEBUG_SEARCH_COMPOSER, "Candidates before search, %@", candidates ?? "nil")
         if !_searchWorkItem.isCancelled {
             _searchWorkItem.cancel()
         }
-        _candidates = [NSAttributedString(string: "Searching...")] // default candidates
+        candidates = [NSAttributedString(string: "Searching...")] // default candidates
 
         var workItem: DispatchWorkItem!
         workItem = DispatchWorkItem {
@@ -362,29 +349,28 @@ private extension SearchComposer {
             guard !workItem.isCancelled else { return }
 
             self._searchLock.lock()
-            self._candidates = newCandidates
+            self.candidates = newCandidates
             if workItem.isCancelled {
                 self._searchLock.unlock()
                 return
             }
             DispatchQueue.main.async {
+                defer { self._searchLock.unlock() }
                 if workItem.isCancelled {
-                    self._searchLock.unlock()
                     return
                 }
                 InputMethodServer.shared.showOrHideCandidates(composer: self)
-                self._searchLock.unlock()
             }
         }
         _searchWorkItem = workItem
 
         if keyword.isEmpty {
             _searchLock.lock()
-            _candidates = nil
+            candidates = nil
             _searchLock.unlock()
         } else {
             _searchQueue.async(execute: _searchWorkItem)
         }
-        dlog(DEBUG_SEARCH_COMPOSER, "Candidates after search, %@", _candidates ?? "nil")
+        dlog(DEBUG_SEARCH_COMPOSER, "Candidates after search, %@", candidates ?? "nil")
     }
 }

--- a/OSXCore/SearchComposer.swift
+++ b/OSXCore/SearchComposer.swift
@@ -262,6 +262,9 @@ extension SearchComposer {
             }
             DispatchQueue.main.async {
                 defer { self._searchLock.unlock() }
+                guard self.delegate != nil else {
+                    return
+                }
                 guard !workItem.isCancelled else {
                     return
                 }


### PR DESCRIPTION
SearchSource.unknown은 아직 반영되지 않았는데, 블럭 잡아서 검색시 한글/영어를 모두 검색하기 위한 옵션입니다.

- 한글/영어 search composer  객체를 병합합니다
- #688 댓글의 '검색중...'이 입력되는 문제를 수정합니다. 
- fix #688 한자모드 해제 후 검색결과 갱신되는 문제를 수정합니다.
- 영어일때 위아래 방향키가 동작하지 않는 문제를 수정합니다.


@JimJeon  @presto95  혹시 시간 되시면 한번 봐주셔요