### PR TITLE
Update preferences to mention correct system preferences

### DIFF
--- a/Preferences/Base.lproj/Preferences.xib
+++ b/Preferences/Base.lproj/Preferences.xib
@@ -224,7 +224,8 @@
                                                                 <string key="title">맥 내장 입력기와 마찬가지로 Caps Lock으로 언어 전환을 하거나,
 PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
 
-&lt;시스템 환경설정 → 키보드 → 단축키 → 입력 소스&gt;에서 &lt;Caps Lock 키로 마지막으로 사용한 라틴 입력 소스 전환&gt; 설정을 켜고,
+&lt;시스템 환경설정 → 키보드 → 입력 소스&gt;에서
+&lt;Caps Lock 키로 마지막으로 사용한 라틴 입력 소스 전환&gt; 설정을 켜고,
 &lt;시스템 환경설정 → 보안 및 개인 정보 보호 → 개인 정보 보호 →
 입력 모니터링&gt;에서 &lt;구름 입력기&gt; 설정을 켜주세요.</string>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -252,12 +253,12 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </connections>
                                                         </button>
                                                         <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M08-TU-Mtg" userLabel="단축키 설정 설명">
-                                                            <rect key="frame" x="-2" y="155" width="361" height="48"/>
+                                                            <rect key="frame" x="-2" y="155" width="369" height="48"/>
                                                             <textFieldCell key="cell" enabled="NO" allowsUndo="NO" sendsActionOnEndEditing="YES" id="hoy-bb-wPo">
                                                                 <font key="font" metaFont="system"/>
-                                                                <string key="title">Caps Lock을 사용하려면 &lt;시스템 환경설정 → 키보드 → 단축키 →
-입력 소스&gt;에서 &lt;Caps Lock 키로 마지막으로 사용한 라틴 입력 소스
-전환&gt; 설정을 켜주세요.</string>
+                                                                <string key="title">Caps Lock을 사용하려면 &lt;시스템 환경설정 → 키보드 → 입력
+소스&gt;에서 &lt;Caps Lock 키로 마지막으로 사용한 라틴 입력 소스 전환&gt;
+설정을 켜주세요.</string>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
@@ -273,12 +274,14 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </connections>
                                                         </button>
                                                         <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ogf-Zd-3HE" userLabel="단축키 설정 설명">
-                                                            <rect key="frame" x="-2" y="32" width="343" height="80"/>
+                                                            <rect key="frame" x="-2" y="32" width="351" height="80"/>
                                                             <textFieldCell key="cell" enabled="NO" allowsUndo="NO" sendsActionOnEndEditing="YES" id="Cbq-10-2mL">
                                                                 <font key="font" metaFont="system"/>
                                                                 <string key="title">구름에서 제공하는 단축키 대신 시스템 단축키를 지정해 자판을
 전환할 수도 있습니다.
-시스템 환경설정 → 키보드 → 단축키 → 입력 소스에서 설정 ⇧스페이스와 같이 ⇧가 포함된 단축키로 설정하려면 Fn 키와 함께 눌러주세요. (예: Fn+⇧+스페이스)</string>
+&lt;시스템 환경설정 → 키보드 → 단축키 → 입력 소스&gt;에서 설정하며,
+⇧스페이스와 같이 ⇧가 포함된 단축키로 설정하려면 Fn 키와 함께
+눌러주세요. (예: Fn+⇧+스페이스)</string>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
@@ -537,7 +540,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </connections>
                                                         </button>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Qtg-ji-dS0">
-                                                            <rect key="frame" x="-2" y="-2" width="318" height="18"/>
+                                                            <rect key="frame" x="18" y="-2" width="318" height="18"/>
                                                             <buttonCell key="cell" type="check" title="실험 버전이 있으면 실험 버전 업데이트 알림을 받겠습니다" bezelStyle="regularSquare" imagePosition="left" inset="2" id="76s-8b-LUT">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>

--- a/Preferences/Base.lproj/Preferences.xib
+++ b/Preferences/Base.lproj/Preferences.xib
@@ -270,7 +270,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                                 <font key="font" metaFont="system"/>
                                                             </buttonCell>
                                                             <connections>
-                                                                <action selector="openKeyboardPreferenceWithSender:" target="DMm-2g-KCR" id="zi4-Wn-x2u"/>
+                                                                <action selector="openKeyboardInputSourcesPreferenceWithSender:" target="DMm-2g-KCR" id="chs-d6-2SE"/>
                                                             </connections>
                                                         </button>
                                                         <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ogf-Zd-3HE" userLabel="단축키 설정 설명">
@@ -293,7 +293,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                                 <font key="font" metaFont="system"/>
                                                             </buttonCell>
                                                             <connections>
-                                                                <action selector="openKeyboardPreferenceWithSender:" target="DMm-2g-KCR" id="6Ub-WI-1T5"/>
+                                                                <action selector="openKeyboardShortcutsPreferenceWithSender:" target="DMm-2g-KCR" id="Po7-lt-mKd"/>
                                                             </connections>
                                                         </button>
                                                     </subviews>

--- a/Preferences/PreferenceViewController.swift
+++ b/Preferences/PreferenceViewController.swift
@@ -121,11 +121,20 @@ final class PreferenceViewController: NSViewController {
 
     // MARK: IBAction
 
-    @IBAction private func openKeyboardPreference(sender _: NSControl) {
+    @IBAction private func openKeyboardShortcutsPreference(sender _: NSControl) {
         runAppleScript("""
             tell application "System Preferences"
                 activate
                 reveal anchor "ShortcutsTab" of pane id "com.apple.preference.keyboard"
+            end tell
+        """)
+    }
+
+    @IBAction private func openKeyboardInputSourcesPreference(sender _: NSControl) {
+        runAppleScript("""
+            tell application "System Preferences"
+                activate
+                reveal anchor "InputSources" of pane id "com.apple.preference.keyboard"
             end tell
         """)
     }


### PR DESCRIPTION
키보드 → 단축키로 가는 버튼과 Caps Lock 설정을 위해 키보드 → 입력 소스로 가는 버튼을 분리합니다. 기존에 Text Field 안에서 U+2028(Line Separator)로 줄바꿈 되는 곳도 있었는데 이번에 \n으로 바꿨습니다.

적용 후의 화면입니다.

![Screenshot 2020-08-15 08 52 58](https://user-images.githubusercontent.com/853977/90300747-01ef0d00-ded7-11ea-8233-eed66b89cffe.png)