### PR TITLE
Remove duplicates from `SearchSource.search`

### DIFF
--- a/GureumTests/GureumTests.swift
+++ b/GureumTests/GureumTests.swift
@@ -101,7 +101,7 @@ class GureumTests: XCTestCase {
     func testSearchEmoticonTable() {
         let bundle = Bundle(for: HGKeyboard.self)
         let path: String? = bundle.path(forResource: "emoji", ofType: "txt", inDirectory: "hanja")
-        let table: HGHanjaTable = HGHanjaTable(contentOfFile: path!)!
+        let table = HGHanjaTable(contentOfFile: path!)!
         let list: HGHanjaList = table.hanjas(byPrefixSearching: "hushed") ?? HGHanjaList() // 현재 5글자 이상만 가능
         XCTAssert(list.count > 0)
     }

--- a/OSXCore/HangulComposer.swift
+++ b/OSXCore/HangulComposer.swift
@@ -45,7 +45,7 @@ func representableString(ucsString: UnsafePointer<HGUCSChar>) -> String {
         return NSString(ucsString: convertUnicode(ucsString) + 1) as String
     }
     if ucsString[1] == 0x1160 {
-        let fill: NSMutableString = NSMutableString(ucsString: ucsString, length: 1)
+        let fill = NSMutableString(ucsString: ucsString, length: 1)!
         fill.append(NSString(ucsString: ucsString + 2, length: 1) as String)
         return fill as String
     }

--- a/OSXCore/InputController.swift
+++ b/OSXCore/InputController.swift
@@ -50,7 +50,7 @@ enum InputEvent {
 @objc(GureumInputController)
 public class InputController: IMKInputController {
     var receiver: InputReceiver!
-    var lastFlags: NSEvent.ModifierFlags = NSEvent.ModifierFlags(rawValue: 0)
+    var lastFlags = NSEvent.ModifierFlags(rawValue: 0)
     var updating = false
 
     override init!(server: IMKServer, delegate: Any!, client inputClient: Any) {

--- a/OSXCore/SearchComposer.swift
+++ b/OSXCore/SearchComposer.swift
@@ -59,8 +59,8 @@ final class SearchComposer: Composer {
     public private(set) var commitString = ""
 
     // 검색을 위한 백그라운드 스레드
-    private var _searchWorkItem: DispatchWorkItem = DispatchWorkItem {}
-    private var _searchQueue: DispatchQueue = DispatchQueue.global(qos: .userInitiated)
+    private var _searchWorkItem = DispatchWorkItem {}
+    private var _searchQueue = DispatchQueue.global(qos: .userInitiated)
     private let _searchLock = NSLock()
 
     var showsCandidateWindow = true

--- a/OSXCore/SearchPool.swift
+++ b/OSXCore/SearchPool.swift
@@ -18,8 +18,7 @@ protocol SearchSource {
 
 extension SearchSource {
     func search(_ keyword: String, workItem: DispatchWorkItem!) -> [NSAttributedString] {
-        // TODO: 중복 제거?
-        collect(keyword, workItem: workItem).sorted(by: { $0.score < $1.score }).map {
+        let collection: [NSAttributedString] = collect(keyword, workItem: workItem).sorted(by: { $0.score < $1.score }).map {
             #if DEBUG
                 let s = "\($0.candidate): \($0.description) (\($0.score))"
             #else
@@ -27,6 +26,15 @@ extension SearchSource {
             #endif
             return NSAttributedString(string: s)
         }
+
+        var keys: Set<NSAttributedString> = []
+        var result: [NSAttributedString] = []
+        for item in collection {
+            if keys.insert(item).inserted {
+                result.append(item)
+            }
+        }
+        return result
     }
 }
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -48,8 +48,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   cdebug: 0d0b7207fa996236ee9e07e5988e5e39a1d94a28
-  Crashlytics: 540b7e5f5da5a042647227a5e3ac51d85eed06df
-  Fabric: 706c8b8098fff96c33c0db69cbf81f9c551d0d74
+  Crashlytics: 9220f5bc89e7a618df411b4f639389dbfb0e03d2
+  Fabric: ea977e3cd9c20425516d3dafd3bf8c941c51223f
   FoundationExtension: 56c1c923c9a3bc69c5a5ac08c47c8f2f57b06288
   Fuse: 48eaf66d0c407c7f8b0ddb168888dc4637e87f14
   MASShortcut: d9e4909e878661cc42877cc9d6efbe638273ab57


### PR DESCRIPTION
Fix #731.

한 글자짜리 변환의 경우엔 hanjac.txt와 hanjar.txt의 결과에서만 중복을 제거하면 될 것 같은데, 그냥 일반적으로 구현했습니다.
score로 정렬한 후 뒤쪽에 있는 중복된 항목을 제거합니다.