### PR TITLE
Remove duplicates from `SearchPool.collect` instead

### DIFF
--- a/GureumTests/GureumTests.swift
+++ b/GureumTests/GureumTests.swift
@@ -660,6 +660,16 @@ class GureumTests: XCTestCase {
         }
     }
 
+    func testSearchPoolWithoutDuplicate() {
+        for (pool, key, test) in [
+            (SearchSourceConst.koreanSingle, "구", "九"),
+        ] {
+            let workItem = DispatchWorkItem {}
+            let candidates = pool.collect(key, workItem: workItem)
+            XCTAssertEqual(1, candidates.filter { $0.candidate.value == test }.count)
+        }
+    }
+
 //    func testSelection() {
 //        for app in apps {
 //            app.client.string = "한"

--- a/GureumTests/GureumTests.swift
+++ b/GureumTests/GureumTests.swift
@@ -656,7 +656,7 @@ class GureumTests: XCTestCase {
             let workItem = DispatchWorkItem {}
             let candidates = pool.collect(key, workItem: workItem)
             let c = candidates[0]
-            XCTAssertTrue(c.candidate == test || c.description.contains(test))
+            XCTAssertTrue(c.candidate.value == test || c.candidate.description.contains(test))
         }
     }
 


### PR DESCRIPTION
Follow up of #735.

`SearchSource.search` 대신 `SearchPool.collect`에서 중복을 제거합니다.