### PR TITLE
Add option to select right toggle key

### DIFF
--- a/OSXCore/Configuration.swift
+++ b/OSXCore/Configuration.swift
@@ -39,8 +39,8 @@ enum ConfigurationName {
     public static let hangulNonChoseongCombination = "HangulNonChoseongCombination"
     /// 세벌식 정석 강요.
     public static let hangulForceStrictCombinationRule = "HangulForceStrictCombinationRule"
-    /// 우측 커맨드 키로 언어 전환
-    public static let switchLanguageForRightGui = "SwitchLanguageForRightGui"
+    /// 우측 키로 언어 전환
+    public static let rightToggleKey = "RightToggleKey"
 
     /// 업데이트 알림 받기
     public static let updateNotification = "UpdateNotification"
@@ -98,7 +98,7 @@ public class Configuration: UserDefaults {
             ConfigurationName.hangulAutoReorder: false,
             ConfigurationName.hangulNonChoseongCombination: false,
             ConfigurationName.hangulForceStrictCombinationRule: false,
-            ConfigurationName.switchLanguageForRightGui: false,
+            ConfigurationName.rightToggleKey: 0,
 
             ConfigurationName.updateNotification: true,
             ConfigurationName.updateNotificationExperimental: false,
@@ -245,13 +245,13 @@ public class Configuration: UserDefaults {
         }
     }
 
-    /// 우측 커맨드 키로 언어 전환
-    public var switchLanguageForRightGui: Bool {
+    /// 우측 키로 언어 전환
+    public var rightToggleKey: Int {
         get {
-            bool(forKey: ConfigurationName.switchLanguageForRightGui)
+            integer(forKey: ConfigurationName.rightToggleKey)
         }
         set {
-            set(newValue, forKey: ConfigurationName.switchLanguageForRightGui)
+            set(newValue, forKey: ConfigurationName.rightToggleKey)
         }
     }
 

--- a/OSXCore/InputController.swift
+++ b/OSXCore/InputController.swift
@@ -37,7 +37,7 @@ struct InputResult: Equatable {
 enum ChangeLayout {
     case toggle
     case toggleByCapsLock
-    case toggleByRightGui
+    case toggleByRightKey
     case hangul
     case roman
     case search
@@ -157,9 +157,9 @@ public extension InputController { // IMKServerInputHandleEvent
                 }
             }
 
-            if InputMethodServer.shared.io.resolveRightGuiPressed() {
-                let result = receiver.input(event: .changeLayout(.toggleByRightGui, true), client: client)
-                dlog(DEBUG_IOKIT_EVENT, "controller detected right gui")
+            if InputMethodServer.shared.io.resolveRightKeyPressed() {
+                let result = receiver.input(event: .changeLayout(.toggleByRightKey, true), client: client)
+                dlog(DEBUG_IOKIT_EVENT, "controller detected right key")
                 return result.processed
             }
 

--- a/OSXCore/InputReceiver.swift
+++ b/OSXCore/InputReceiver.swift
@@ -127,7 +127,7 @@ public class InputReceiver: InputTextDelegate {
     func input(event: InputEvent, client sender: IMKTextInput & IMKUnicodeTextInput) -> InputResult {
         switch event {
         case let .changeLayout(layout, processed):
-            let innerLayout = layout == .toggleByCapsLock || layout == .toggleByRightGui ? .toggle : layout
+            let innerLayout = layout == .toggleByCapsLock || layout == .toggleByRightKey ? .toggle : layout
             let result = composer.changeLayout(innerLayout, client: sender)
             // 합성 후보가 있다면 보여준다
             InputMethodServer.shared.showOrHideCandidates(controller: controller)

--- a/Preferences/Base.lproj/Preferences.xib
+++ b/Preferences/Base.lproj/Preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -29,13 +29,13 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <view translatesAutoresizingMaskIntoConstraints="NO" id="Mwx-RP-qRv">
-                                    <rect key="frame" x="0.0" y="-43" width="415" height="961"/>
+                                    <rect key="frame" x="0.0" y="-56" width="415" height="974"/>
                                     <subviews>
                                         <stackView distribution="fillEqually" orientation="vertical" alignment="leading" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kLe-bm-FOO">
-                                            <rect key="frame" x="20" y="16" width="375" height="929"/>
+                                            <rect key="frame" x="20" y="16" width="375" height="942"/>
                                             <subviews>
                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g8D-VJ-ONL">
-                                                    <rect key="frame" x="0.0" y="784" width="375" height="145"/>
+                                                    <rect key="frame" x="0.0" y="797" width="375" height="145"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a8y-l9-yXh">
                                                             <rect key="frame" x="-2" y="129" width="90" height="16"/>
@@ -207,10 +207,10 @@
                                                     </customSpacing>
                                                 </stackView>
                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Td-o5-z1h">
-                                                    <rect key="frame" x="0.0" y="354" width="375" height="410"/>
+                                                    <rect key="frame" x="0.0" y="380" width="375" height="397"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DRr-ZG-wMG">
-                                                            <rect key="frame" x="-2" y="394" width="101" height="16"/>
+                                                            <rect key="frame" x="-2" y="381" width="101" height="16"/>
                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="시스템 단축키 설정" id="45X-EX-BbZ">
                                                                 <font key="font" metaFont="systemBold"/>
                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -218,32 +218,66 @@
                                                             </textFieldCell>
                                                         </textField>
                                                         <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kC8-kH-2z7" userLabel="단축키 설정 설명">
-                                                            <rect key="frame" x="-2" y="271" width="379" height="112"/>
+                                                            <rect key="frame" x="-2" y="274" width="369" height="96"/>
                                                             <textFieldCell key="cell" enabled="NO" allowsUndo="NO" sendsActionOnEndEditing="YES" id="Ndr-tA-evW">
                                                                 <font key="font" metaFont="system"/>
                                                                 <string key="title">맥 내장 입력기와 마찬가지로 Caps Lock으로 언어 전환을 하거나,
-PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
+PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 수 있습니다.
 
-&lt;시스템 환경설정 → 키보드 → 입력 소스&gt;에서
-&lt;Caps Lock 키로 마지막으로 사용한 라틴 입력 소스 전환&gt; 설정을 켜고,
-&lt;시스템 환경설정 → 보안 및 개인 정보 보호 → 개인 정보 보호 →
-입력 모니터링&gt;에서 &lt;구름 입력기&gt; 설정을 켜주세요.</string>
+오른쪽 키로 언어 전환을 하려면 &lt;시스템 환경설정 → 보안 및
+개인 정보 보호 → 개인 정보 보호 → 입력 모니터링&gt;에서
+&lt;구름 입력기&gt; 설정을 켜주세요.</string>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
                                                         </textField>
-                                                        <button translatesAutoresizingMaskIntoConstraints="NO" id="jGI-mn-eCd">
-                                                            <rect key="frame" x="-2" y="244" width="150" height="18"/>
-                                                            <buttonCell key="cell" type="check" title="오른쪽 ⌘ 키로 언어 전환" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="HEa-EU-G5x">
-                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                                <font key="font" metaFont="system"/>
-                                                            </buttonCell>
-                                                            <connections>
-                                                                <action selector="switchLanguageForRightGuiValueChanged:" target="DMm-2g-KCR" id="Kdi-Vy-HhR"/>
-                                                            </connections>
-                                                        </button>
+                                                        <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="80" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SYs-9w-bvA">
+                                                            <rect key="frame" x="0.0" y="243" width="306" height="20"/>
+                                                            <subviews>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zdz-kF-GPl">
+                                                                    <rect key="frame" x="-2" y="2" width="120" height="16"/>
+                                                                    <textFieldCell key="cell" lineBreakMode="clipping" title="오른쪽 키로 언어 전환:" id="myQ-yv-6PZ">
+                                                                        <font key="font" usesAppearanceFont="YES"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="O2x-rR-7JO">
+                                                                    <rect key="frame" x="193" y="-4" width="117" height="25"/>
+                                                                    <popUpButtonCell key="cell" type="push" title="하지 않음" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="gpa-BJ-0Mf" id="ZdG-zP-BO7">
+                                                                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                                        <font key="font" metaFont="menu"/>
+                                                                        <menu key="menu" id="Ft9-Ec-IoD">
+                                                                            <items>
+                                                                                <menuItem title="하지 않음" state="on" id="gpa-BJ-0Mf">
+                                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                                </menuItem>
+                                                                                <menuItem title="⌘ Command" id="SsR-ab-evp"/>
+                                                                                <menuItem title="⌥ Option" id="9vh-Qo-MRc">
+                                                                                    <modifierMask key="keyEquivalentModifierMask" option="YES"/>
+                                                                                </menuItem>
+                                                                                <menuItem title="⌃ Control" id="MKU-NP-Xzr">
+                                                                                    <modifierMask key="keyEquivalentModifierMask" control="YES"/>
+                                                                                </menuItem>
+                                                                            </items>
+                                                                        </menu>
+                                                                    </popUpButtonCell>
+                                                                    <connections>
+                                                                        <action selector="rightToggleKeyValueChanged:" target="DMm-2g-KCR" id="OVm-jb-sdZ"/>
+                                                                    </connections>
+                                                                </popUpButton>
+                                                            </subviews>
+                                                            <visibilityPriorities>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                            </visibilityPriorities>
+                                                            <customSpacing>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                            </customSpacing>
+                                                        </stackView>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="up6-aF-gPR">
-                                                            <rect key="frame" x="-6" y="207" width="209" height="32"/>
+                                                            <rect key="frame" x="-7" y="205" width="204" height="32"/>
                                                             <buttonCell key="cell" type="push" title="입력 모니터링 설정하러 이동하기" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="hfm-ub-tBd">
                                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -253,7 +287,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </connections>
                                                         </button>
                                                         <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M08-TU-Mtg" userLabel="단축키 설정 설명">
-                                                            <rect key="frame" x="-2" y="155" width="369" height="48"/>
+                                                            <rect key="frame" x="-2" y="153" width="368" height="48"/>
                                                             <textFieldCell key="cell" enabled="NO" allowsUndo="NO" sendsActionOnEndEditing="YES" id="hoy-bb-wPo">
                                                                 <font key="font" metaFont="system"/>
                                                                 <string key="title">Caps Lock을 사용하려면 &lt;시스템 환경설정 → 키보드 → 입력
@@ -264,7 +298,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </textFieldCell>
                                                         </textField>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="N4p-Iu-NjD">
-                                                            <rect key="frame" x="-6" y="116" width="171" height="32"/>
+                                                            <rect key="frame" x="-7" y="115" width="166" height="32"/>
                                                             <buttonCell key="cell" type="push" title="키보드 설정하러 이동하기" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="t0Y-xg-dcU">
                                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -274,7 +308,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </connections>
                                                         </button>
                                                         <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ogf-Zd-3HE" userLabel="단축키 설정 설명">
-                                                            <rect key="frame" x="-2" y="32" width="351" height="80"/>
+                                                            <rect key="frame" x="-2" y="31" width="350" height="80"/>
                                                             <textFieldCell key="cell" enabled="NO" allowsUndo="NO" sendsActionOnEndEditing="YES" id="Cbq-10-2mL">
                                                                 <font key="font" metaFont="system"/>
                                                                 <string key="title">구름에서 제공하는 단축키 대신 시스템 단축키를 지정해 자판을
@@ -287,7 +321,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </textFieldCell>
                                                         </textField>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tMq-UC-GBP">
-                                                            <rect key="frame" x="-6" y="-7" width="171" height="32"/>
+                                                            <rect key="frame" x="-7" y="-7" width="166" height="32"/>
                                                             <buttonCell key="cell" type="push" title="키보드 설정하러 이동하기" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="OPL-eq-ykB">
                                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -318,11 +352,11 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                         <real value="3.4028234663852886e+38"/>
                                                     </customSpacing>
                                                 </stackView>
-                                                <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="5" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zYw-Lc-Fgh">
-                                                    <rect key="frame" x="0.0" y="272" width="327" height="62"/>
+                                                <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zYw-Lc-Fgh">
+                                                    <rect key="frame" x="0.0" y="286" width="327" height="74"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dCm-f8-tKJ">
-                                                            <rect key="frame" x="-2" y="46" width="101" height="16"/>
+                                                            <rect key="frame" x="-2" y="58" width="101" height="16"/>
                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="로마자 입력기 설정" id="1kr-cl-A2e">
                                                                 <font key="font" metaFont="systemBold"/>
                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -330,13 +364,13 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </textFieldCell>
                                                         </textField>
                                                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="80" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vwy-Ul-fDb">
-                                                            <rect key="frame" x="0.0" y="21" width="327" height="20"/>
+                                                            <rect key="frame" x="0.0" y="27" width="327" height="20"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TKK-is-ROX">
                                                                     <rect key="frame" x="-2" y="2" width="91" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="키보드 레이아웃:" id="fcn-6t-Jdv">
                                                                         <font key="font" metaFont="system"/>
-                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
@@ -371,7 +405,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </customSpacing>
                                                         </stackView>
                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="phv-uO-218">
-                                                            <rect key="frame" x="-2" y="0.0" width="322" height="16"/>
+                                                            <rect key="frame" x="-2" y="0.0" width="323" height="16"/>
                                                             <textFieldCell key="cell" lineBreakMode="clipping" title="&quot;로마자&quot; 입력기와 한글 입력기 단축키 양쪽에 모두 적용됩니다" id="1yh-7K-4cy">
                                                                 <font key="font" usesAppearanceFont="YES"/>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -391,10 +425,10 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                     </customSpacing>
                                                 </stackView>
                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zbm-lz-J9a">
-                                                    <rect key="frame" x="0.0" y="80" width="345" height="172"/>
+                                                    <rect key="frame" x="0.0" y="84" width="346" height="182"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yjR-ur-FpL">
-                                                            <rect key="frame" x="-2" y="156" width="90" height="16"/>
+                                                            <rect key="frame" x="-2" y="166" width="90" height="16"/>
                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="한글 입력기 설정" id="HIp-u9-CIf">
                                                                 <font key="font" metaFont="systemBold"/>
                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -402,7 +436,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </textFieldCell>
                                                         </textField>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JYx-Sc-lao">
-                                                            <rect key="frame" x="-2" y="129" width="284" height="18"/>
+                                                            <rect key="frame" x="-2" y="138" width="288" height="18"/>
                                                             <buttonCell key="cell" type="check" title="한글 입력기일 때 역따옴표(`)로 원화 기호(₩) 입력" bezelStyle="regularSquare" imagePosition="left" inset="2" id="2iT-lY-Scx" userLabel="한글 입력기일 때 역따옴표(`)로 원화 기호(₩) 입력">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -412,7 +446,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </connections>
                                                         </button>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DXg-Ha-7zY">
-                                                            <rect key="frame" x="-2" y="104" width="230" height="18"/>
+                                                            <rect key="frame" x="-2" y="111" width="234" height="18"/>
                                                             <buttonCell key="cell" type="check" title="완성되지 않은 낱자 자동 교정 (모아치기)" bezelStyle="regularSquare" imagePosition="left" inset="2" id="HZu-6J-gbz">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -422,7 +456,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </connections>
                                                         </button>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AHr-Ou-hBi">
-                                                            <rect key="frame" x="-2" y="79" width="305" height="18"/>
+                                                            <rect key="frame" x="-2" y="84" width="309" height="18"/>
                                                             <buttonCell key="cell" type="check" title="두벌식 초성 조합 중에도 종성 결합 허용 (MS윈도 호환)" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Phf-eg-t0A">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -432,7 +466,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </connections>
                                                         </button>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JOz-3z-VAl" userLabel="Strict Combination">
-                                                            <rect key="frame" x="-2" y="54" width="108" height="18"/>
+                                                            <rect key="frame" x="-2" y="57" width="112" height="18"/>
                                                             <buttonCell key="cell" type="check" title="세벌식 정석 강요" bezelStyle="regularSquare" imagePosition="left" inset="2" id="cQP-uo-ggW" userLabel="세벌식 종성 결합 허용하지 않음">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -442,7 +476,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </connections>
                                                         </button>
                                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="Wjk-Ru-yFr">
-                                                            <rect key="frame" x="-2" y="29" width="232" height="18"/>
+                                                            <rect key="frame" x="-2" y="30" width="236" height="18"/>
                                                             <buttonCell key="cell" type="check" title="Esc 키로 로마자 자판으로 전환 (vi 모드)" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="oYM-mR-7hZ">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -452,10 +486,10 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </connections>
                                                         </button>
                                                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="80" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4dQ-Ty-1Es">
-                                                            <rect key="frame" x="0.0" y="0.0" width="345" height="20"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="346" height="20"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YGK-Vi-f1X">
-                                                                    <rect key="frame" x="-2" y="2" width="109" height="16"/>
+                                                                    <rect key="frame" x="-2" y="2" width="110" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="⌥(option) 키 동작:" id="jWu-1H-vJQ">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -463,7 +497,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="F1x-Bk-yYe" userLabel="option 키 동작 Combo Box">
-                                                                    <rect key="frame" x="185" y="-4" width="163" height="26"/>
+                                                                    <rect key="frame" x="186" y="-4" width="163" height="26"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="20" id="OF1-Ax-F9a"/>
                                                                         <constraint firstAttribute="width" constant="160" id="vV1-ZH-Rjt"/>
@@ -519,10 +553,10 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                     </customSpacing>
                                                 </stackView>
                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="epY-p9-ex8">
-                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="60"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UPK-Nf-1O5">
-                                                            <rect key="frame" x="-2" y="44" width="75" height="16"/>
+                                                            <rect key="frame" x="-2" y="48" width="75" height="16"/>
                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="업데이트 설정" id="nWa-hO-Ybq">
                                                                 <font key="font" metaFont="systemBold"/>
                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -530,7 +564,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </textFieldCell>
                                                         </textField>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TrR-dR-6Bo">
-                                                            <rect key="frame" x="-2" y="20" width="379" height="18"/>
+                                                            <rect key="frame" x="-2" y="23" width="377" height="18"/>
                                                             <buttonCell key="cell" type="check" title="업데이트 알림을 받겠습니다" bezelStyle="regularSquare" imagePosition="left" inset="2" id="qth-k4-ZDz">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -540,7 +574,7 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                                                             </connections>
                                                         </button>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Qtg-ji-dS0">
-                                                            <rect key="frame" x="18" y="-2" width="318" height="18"/>
+                                                            <rect key="frame" x="18" y="-1" width="321" height="18"/>
                                                             <buttonCell key="cell" type="check" title="실험 버전이 있으면 실험 버전 업데이트 알림을 받겠습니다" bezelStyle="regularSquare" imagePosition="left" inset="2" id="76s-8b-LUT">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -637,8 +671,8 @@ PC처럼 오른쪽 커맨드 키로 언어 전환을 할 수 있습니다.
                 <outlet property="inputModeSearchShortcutView" destination="H7u-hL-ncz" id="31Z-g1-m5g"/>
                 <outlet property="optionKeyComboBox" destination="l2R-fW-dqw" id="lmx-bw-58h"/>
                 <outlet property="overridingKeyboardNameComboBox" destination="djp-BV-Tu6" id="zKK-rV-G9N"/>
+                <outlet property="rightToggleKeyButton" destination="O2x-rR-7JO" id="QxE-Xf-9nc"/>
                 <outlet property="romanModeByEscapeKeyButton" destination="oYM-mR-7hZ" id="RSA-NS-Kza"/>
-                <outlet property="switchLanguageForRightGuiButton" destination="jGI-mn-eCd" id="8bx-bw-bPs"/>
                 <outlet property="updateNotificationButton" destination="TrR-dR-6Bo" id="PIM-J6-iux"/>
                 <outlet property="updateNotificationExperimentalButton" destination="Qtg-ji-dS0" id="brm-A8-IV4"/>
                 <outlet property="view" destination="se5-gp-TjO" id="x0B-I2-MHL"/>

--- a/Preferences/PreferenceViewController.swift
+++ b/Preferences/PreferenceViewController.swift
@@ -8,6 +8,7 @@
 
 import Cocoa
 import Foundation
+import SwiftIOKit
 
 import MASShortcut
 #if !USE_PREFPANE
@@ -31,8 +32,8 @@ final class PreferenceViewController: NSViewController {
     @IBOutlet private var hangulForceStrictCombinationRuleButton: NSButton!
     /// Esc 키로 로마자 자판으로 전환 (vi 모드).
     @IBOutlet private var romanModeByEscapeKeyButton: NSButton!
-    /// 우측 커맨드 키로 언어 전환
-    @IBOutlet private var switchLanguageForRightGuiButton: NSButton!
+    /// 우측 키로 언어 전환
+    @IBOutlet private var rightToggleKeyButton: NSPopUpButton!
 
     /// 입력기 바꾸기 단축키.
     @IBOutlet private var inputModeExchangeShortcutView: MASShortcutView!
@@ -82,7 +83,16 @@ final class PreferenceViewController: NSViewController {
         hangulAutoReorderButton.state = isOn(configuration.hangulAutoReorder)
         hangulNonChoseongCombinationButton.state = isOn(configuration.hangulNonChoseongCombination)
         hangulForceStrictCombinationRuleButton.state = isOn(configuration.hangulForceStrictCombinationRule)
-        switchLanguageForRightGuiButton.state = isOn(configuration.switchLanguageForRightGui)
+        switch configuration.rightToggleKey {
+        case kHIDUsage_KeyboardRightGUI:
+            rightToggleKeyButton.selectItem(at: 1)
+        case kHIDUsage_KeyboardRightAlt:
+            rightToggleKeyButton.selectItem(at: 2)
+        case kHIDUsage_KeyboardRightControl:
+            rightToggleKeyButton.selectItem(at: 3)
+        default:
+            rightToggleKeyButton.selectItem(at: 0)
+        }
         if (0 ..< optionKeyComboBox.numberOfItems).contains(configuration.optionKeyBehavior) {
             optionKeyComboBox.selectItem(at: configuration.optionKeyBehavior)
         }
@@ -183,8 +193,19 @@ final class PreferenceViewController: NSViewController {
         configuration.hangulForceStrictCombinationRule = sender.state == .on
     }
 
-    @IBAction private func switchLanguageForRightGuiValueChanged(_ sender: NSButton) {
-        configuration.switchLanguageForRightGui = sender.state == .on
+    @IBAction private func rightToggleKeyValueChanged(_ sender: NSPopUpButton) {
+        configuration.rightToggleKey = {
+            switch sender.indexOfSelectedItem {
+            case 1:
+                return kHIDUsage_KeyboardRightGUI
+            case 2:
+                return kHIDUsage_KeyboardRightAlt
+            case 3:
+                return kHIDUsage_KeyboardRightControl
+            default:
+                return 0
+            }
+        }()
     }
 
     @IBAction private func updateNotificationValueChanged(_ sender: NSButton) {


### PR DESCRIPTION
Ref #772.

업데이트한 환경설정 화면입니다. "시스템 단축키 설정" 아래의 두 번째 문단이 Caps Lock과 입력 모니터링을 둘 다 언급하고 있었는데, 각 버튼 위에 한 문단씩 설명이 있는 형태로 조금 바꿨습니다.

![Screenshot 2021-10-31 17 05 58](https://user-images.githubusercontent.com/853977/139574025-d39cc221-0084-4449-8b21-fc9b703c852a.png)

"오른쪽 키로 언어 전환" 옵션으로 선택할 수 있는 항목입니다.

![Screenshot 2021-10-31 17 07 00](https://user-images.githubusercontent.com/853977/139574030-2f664ca7-e6b8-41af-94fd-31bc64cb1285.png)

사용하는 `kHIDUsage_Keyboard*` 값은 다음과 같습니다. https://opensource.apple.com/source/IOHIDFamily/IOHIDFamily-1090.260.23/IOHIDFamily/IOHIDUsageTables.h.auto.html

```
kHIDUsage_KeyboardRightControl    = 0xE4,    /* Right Control */
kHIDUsage_KeyboardRightAlt    = 0xE6,    /* Right Alt */
kHIDUsage_KeyboardRightGUI    = 0xE7,    /* Right GUI */
```

일단은 `NSPopUpButton`의 `indexOfSelectedItem`으로 처리하고 있는데, 나중에 옵션 순서 바꾸면 Configuration 저장에 문제가 좀 있을 거 같네요.