### PR TITLE
오른쪽 옵션을 기본 한/A 전환 키로

### DIFF
--- a/OSXCore/Configuration.swift
+++ b/OSXCore/Configuration.swift
@@ -98,7 +98,7 @@ public class Configuration: UserDefaults {
             ConfigurationName.hangulAutoReorder: false,
             ConfigurationName.hangulNonChoseongCombination: false,
             ConfigurationName.hangulForceStrictCombinationRule: false,
-            ConfigurationName.rightToggleKey: 0,
+            ConfigurationName.rightToggleKey: kHIDUsage_KeyboardRightAlt,
 
             ConfigurationName.updateNotification: true,
             ConfigurationName.updateNotificationExperimental: false,


### PR DESCRIPTION
맥을 처음 사용하는 사람들이 한/영 키 대신 가장 먼저 찾는 기능이므로, 기본으로 켜져있는게 좋다고 생각합니다.
- command: 다른 단축키를 실수로 눌러서 의도하지 않은 동작이 자주 발생
- control: 미니 레이아웃에는 우측에는 없는 키
- option: 그나마 option이 들어가는 단축키가 적은 편

따라서 옵션 키를 기본으로 두는게 가장 낫습니다.