### PR TITLE
Show modal when checkExperimentalVersion runs

### DIFF
--- a/OSX/GureumMenu.swift
+++ b/OSX/GureumMenu.swift
@@ -25,26 +25,35 @@ extension InputController {
         preferencesWindow.showWindow(nil)
     }
 
-    @IBAction func checkRecentVersion(_: Any) {
-        answers.logMenu(name: "check-version")
-        UpdateManager.shared.requestVersionInfo(mode: .Stable) { info in
+    private func checkVersion(mode: UpdateMode) {
+        var title = ""
+        var version = ""
+        switch mode {
+        case .Stable:
+            title = "업데이트"
+            version = "버전"
+        case .Experimental:
+            title = "실험 버전"
+            version = "실험 버전"
+        }
+        UpdateManager.shared.requestVersionInfo(mode: mode) { info in
             guard let info = info else {
                 let alert = NSAlert()
-                alert.messageText = "구름 입력기 업데이트 확인"
+                alert.messageText = "구름 입력기 \(title) 확인"
                 alert.addButton(withTitle: "확인")
-                alert.informativeText = "업데이트 정보에 접근할 수 없습니다. 인터넷에 연결되어 있지 않거나 구름 업데이트의 버그일 수 있습니다."
+                alert.informativeText = "\(title) 정보에 접근할 수 없습니다. 인터넷에 연결되어 있지 않거나 구름 업데이트의 버그일 수 있습니다."
                 alert.runModal()
                 return
             }
             if info.update.version == info.current {
-                let fmt = "현재 사용하고 있는 구름 입력기 \(info.current ?? "-") 는 최신 버전입니다."
+                let fmt = "현재 사용하고 있는 구름 입력기 \(info.current ?? "-") 는 최신 \(version)입니다."
                 let alert = NSAlert()
-                alert.messageText = "구름 입력기 업데이트 확인"
+                alert.messageText = "구름 입력기 \(title) 확인"
                 alert.addButton(withTitle: "확인")
                 alert.informativeText = fmt
                 alert.runModal()
             } else {
-                var message = "현재 사용하고 있는 구름 입력기는 \(info.current ?? "-") 이고 최신 버전은 \(info.update.version) 입니다. 업데이트는 로그아웃하거나 재부팅해야 적용됩니다."
+                var message = "현재 사용하고 있는 구름 입력기는 \(info.current ?? "-") 이고 최신 \(version)은 \(info.update.version) 입니다. 업데이트는 로그아웃하거나 재부팅해야 적용됩니다."
                 if !info.update.description.isEmpty {
                     message += " 업데이트 요약은 '\(info.update.description)' 입니다."
                 }
@@ -54,7 +63,7 @@ extension InputController {
                     message += " 현재 업데이트 링크를 찾을 수 없습니다. 버그 리포트를 부탁드립니다."
                 }
                 let alert = NSAlert()
-                alert.messageText = "구름 입력기 업데이트 확인"
+                alert.messageText = "구름 입력기 \(title) 확인"
                 alert.addButton(withTitle: "확인")
                 alert.informativeText = message
                 alert.runModal()
@@ -62,19 +71,14 @@ extension InputController {
         }
     }
 
+    @IBAction func checkRecentVersion(_: Any) {
+        answers.logMenu(name: "check-version")
+        checkVersion(mode: .Stable)
+    }
+
     @IBAction func checkExperimentalVersion(_: Any) {
         answers.logMenu(name: "check-experimental")
-        UpdateManager.shared.requestVersionInfo(mode: .Experimental) { info in
-            guard let info = info else {
-                let alert = NSAlert()
-                alert.messageText = "구름 입력기 실험 버전 확인"
-                alert.addButton(withTitle: "확인")
-                alert.informativeText = "현재 운영중인 실험 버전이 없습니다. 나중에 다시 확인해 주세요."
-                alert.runModal()
-                return
-            }
-            NSWorkspace.shared.open(URL(string: info.update.url)!)
-        }
+        checkVersion(mode: .Experimental)
     }
 
     @IBAction func openWebsite(_: Any) {


### PR DESCRIPTION
See https://github.com/gureum/gureum/pull/806#discussion_r857127791.

단어 두 개를 골라서 `UpdateMode`에 따라 대치만 하는 방식으로 `checkRecentVersion`과 `checkExperimentalVersion`을 합했습니다.

과거에는 stable 릴리스가 최신이면 version-experimental.json을 비워두어서 `info`가 없을 때의 메시지가 달랐지만, 지금은 version-experimental.json에 최신 stable 정보가 들어가는 식으로 변경되었기 때문에 통일해도 별 문제가 없을 것 같습니다. stable 버전을 두고 '최신 실험 버전'이라고는 하겠지만, 큰 문제는 없을 것 같습니다.