### PR TITLE
Fix permissions

### DIFF
--- a/OSX/Gureum.entitlements
+++ b/OSX/Gureum.entitlements
@@ -8,5 +8,12 @@
 	<array/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.scripting-targets</key>
+	<dict>
+		<key>com.apple.systempreferences</key>
+		<array>
+			<string>preferencepane.reveal</string>
+		</array>
+	</dict>
 </dict>
 </plist>

--- a/OSX/Gureum.entitlements
+++ b/OSX/Gureum.entitlements
@@ -15,5 +15,9 @@
 			<string>preferencepane.reveal</string>
 		</array>
 	</dict>
+	<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+	<array>
+		<string>/Library/Preferences/.GlobalPreferences.plist</string>
+	</array>
 </dict>
 </plist>

--- a/OSX/GureumAppDelegate.swift
+++ b/OSX/GureumAppDelegate.swift
@@ -65,6 +65,11 @@ class GureumAppDelegate: NSObject, NSApplicationDelegate, GureumApplicationDeleg
 
         UpdateManager.shared.notifyUpdateIfNeeded()
 
+        // 입력 모니터링 권한 요청
+        if #available(macOS 10.15, *) {
+            IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)
+        }
+
         // IMKServer를 띄워야만 입력기가 동작한다
         _ = InputMethodServer.shared
 


### PR DESCRIPTION
- `com.apple.security.scripting-targets`
  - https://stackoverflow.com/questions/52413874/applescript-activate-from-sandboxed-app-does-not-bring-window-to-foreground
  - https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html
  - `sdef /System/Applications/System\ Preferences.app`
- `IOHIDRequesAccess`
  - https://stackoverflow.com/questions/58670785/which-api-is-behind-the-privacy-feature-input-monitoring-in-the-security-syste
- `com.apple.security.temporary-exception.files.home-relative-path.read-only`
  - https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/AppSandboxTemporaryExceptionEntitlements.html

`~/Library/Preferences/.GlobalPreferences.plist`는 일단 temporary-exception으로 추가해 뒀습니다.