### PR TITLE
#149 Jetbrains 호환 기능 추가

### DIFF
--- a/OSXCore/Configuration.swift
+++ b/OSXCore/Configuration.swift
@@ -38,7 +38,7 @@ enum ConfigurationName {
     /// 두벌식 초성 조합 중에도 종성 결합 허용 (MS윈도 호환).
     public static let hangulNonChoseongCombination = "HangulNonChoseongCombination"
     /// 모든 글자를 조합 중인 글자로 취급 (JDK 호환).
-    public static let hangulJDKCompatible = "hangulJDKCompatible"
+    public static let hangulDeferredSymbolCommit = "HangulDeferredSymbolCommit"
     /// 세벌식 정석 강요.
     public static let hangulForceStrictCombinationRule = "HangulForceStrictCombinationRule"
     /// 우측 키로 언어 전환
@@ -98,7 +98,7 @@ public class Configuration: UserDefaults {
             ConfigurationName.hangulWonCurrencySymbolForBackQuote: true,
             ConfigurationName.hangulAutoReorder: false,
             ConfigurationName.hangulNonChoseongCombination: false,
-            ConfigurationName.hangulJDKCompatible: false,
+            ConfigurationName.hangulDeferredSymbolCommit: false,
             ConfigurationName.hangulForceStrictCombinationRule: false,
             ConfigurationName.rightToggleKey: kHIDUsage_KeyboardRightAlt,
 
@@ -238,12 +238,12 @@ public class Configuration: UserDefaults {
     }
 
     /// 모든 글자를 조합중인 글자로 취급 (JDK 호환).
-    public var hangulJDKCompatible: Bool {
+    public var hangulDeferredSymbolCommit: Bool {
         get {
-            bool(forKey: ConfigurationName.hangulJDKCompatible)
+            bool(forKey: ConfigurationName.hangulDeferredSymbolCommit)
         }
         set {
-            set(newValue, forKey: ConfigurationName.hangulJDKCompatible)
+            set(newValue, forKey: ConfigurationName.hangulDeferredSymbolCommit)
         }
     }
 

--- a/OSXCore/Configuration.swift
+++ b/OSXCore/Configuration.swift
@@ -37,6 +37,8 @@ enum ConfigurationName {
     public static let hangulAutoReorder = "HangulAutoReorder"
     /// 두벌식 초성 조합 중에도 종성 결합 허용 (MS윈도 호환).
     public static let hangulNonChoseongCombination = "HangulNonChoseongCombination"
+    /// 모든 글자를 조합 중인 글자로 취급 (JDK 호환).
+    public static let hangulJDKCompatible = "hangulJDKCompatible"
     /// 세벌식 정석 강요.
     public static let hangulForceStrictCombinationRule = "HangulForceStrictCombinationRule"
     /// 우측 키로 언어 전환
@@ -96,6 +98,7 @@ public class Configuration: UserDefaults {
             ConfigurationName.hangulWonCurrencySymbolForBackQuote: true,
             ConfigurationName.hangulAutoReorder: false,
             ConfigurationName.hangulNonChoseongCombination: false,
+            ConfigurationName.hangulJDKCompatible: false,
             ConfigurationName.hangulForceStrictCombinationRule: false,
             ConfigurationName.rightToggleKey: kHIDUsage_KeyboardRightAlt,
 
@@ -231,6 +234,16 @@ public class Configuration: UserDefaults {
         }
         set {
             set(newValue, forKey: ConfigurationName.hangulNonChoseongCombination)
+        }
+    }
+
+    /// 모든 글자를 조합중인 글자로 취급 (JDK 호환).
+    public var hangulJDKCompatible: Bool {
+        get {
+            bool(forKey: ConfigurationName.hangulJDKCompatible)
+        }
+        set {
+            set(newValue, forKey: ConfigurationName.hangulJDKCompatible)
         }
     }
 

--- a/OSXCore/HangulComposer.swift
+++ b/OSXCore/HangulComposer.swift
@@ -93,15 +93,15 @@ final class HangulComposer: NSObject, Composer {
 
     /// 합성을 완료한 문자열.
     private var _commitString: String
-    /// JDK 호환성 모드를 위해 보관중인 문자열.
-    private var _compatiblePreeditString: String
+    /// 합성 중인 문자열. 현재는 JDK 호환 모드에만 사용된다.
+    private var _composedString: String
 
     let inputContext: HGInputContext
     let configuration = Configuration.shared
 
     init(type: HangulComposer.ComposerType) {
         _commitString = ""
-        _compatiblePreeditString = ""
+        _composedString = ""
         let keyboardIdentifier = type.rawValue
         let inputContext = HGInputContext(keyboardIdentifier: keyboardIdentifier)!
         self.inputContext = inputContext
@@ -135,12 +135,12 @@ final class HangulComposer: NSObject, Composer {
 
     var composedString: String {
         let preedit = inputContext.preeditUCSString
-        return _compatiblePreeditString + representableString(ucsString: preedit)
+        return _composedString + representableString(ucsString: preedit)
     }
 
     var originalString: String {
         let preedit = inputContext.preeditUCSString
-        return _compatiblePreeditString + representableString(ucsString: preedit)
+        return _composedString + representableString(ucsString: preedit)
     }
 
     var commitString: String {
@@ -168,15 +168,15 @@ final class HangulComposer: NSObject, Composer {
 
     func cancelComposition() {
         let flushedString: String! = representableString(ucsString: inputContext.flushUCSString())
-        _commitString.append(_compatiblePreeditString)
+        _commitString.append(_composedString)
         _commitString.append(flushedString)
-        _compatiblePreeditString = ""
+        _composedString = ""
     }
 
     func clearCompositionContext() {
         inputContext.reset()
         _commitString = ""
-        _compatiblePreeditString = ""
+        _composedString = ""
     }
 
     func composerSelected() {
@@ -198,9 +198,9 @@ final class HangulComposer: NSObject, Composer {
     {
         // libhangul은 backspace를 키로 받지 않고 별도로 처리한다.
         if keyCode == .delete {
-            // JDK 호환 모드의 경우, _compatiblePreeditString가 있을 경우 그 문자를 우선적으로 지운다
-            if configuration.hangulJDKCompatible, _compatiblePreeditString.isEmpty == false {
-                _compatiblePreeditString = ""
+            // JDK 호환 모드의 경우, _composedString가 있을 경우 그 문자를 우선적으로 지운다
+            if configuration.hangulDeferredSymbolCommit, !_composedString.isEmpty {
+                _composedString.removeLast()
                 return .processed
             }
             return inputContext.backspace() ? .processed : .notProcessed
@@ -222,18 +222,18 @@ final class HangulComposer: NSObject, Composer {
         let ucsString = inputContext.commitUCSString
         let recentCommitString = representableString(ucsString: ucsString)
 
-        if configuration.hangulJDKCompatible {
+        if configuration.hangulDeferredSymbolCommit {
             if handled {
-                _commitString.append(_compatiblePreeditString)
-                _compatiblePreeditString = ""
+                _commitString.append(_composedString)
+                _composedString = ""
                 if recentCommitString.isEmpty {
                     return .processed
                 } else {
                     // 마지막 글자가 한글이 아닌 경우 비조합 문자열로 판단한다.
-                    let lastChar = String(Array(recentCommitString).last!)
+                    let lastChar = String(recentCommitString.last!)
                     if lastChar.range(of: "[ㄱ-ㅎㅏ-ㅣ가-힣]", options: .regularExpression) == nil {
-                        _compatiblePreeditString = lastChar
-                        _commitString.append(String(Array(recentCommitString).dropLast()))
+                        _composedString = lastChar
+                        _commitString.append(String(recentCommitString.dropLast()))
                     } else {
                         _commitString.append(recentCommitString)
                     }

--- a/OSXCore/HangulComposer.swift
+++ b/OSXCore/HangulComposer.swift
@@ -229,11 +229,17 @@ final class HangulComposer: NSObject, Composer {
                 if recentCommitString.isEmpty {
                     return .processed
                 } else {
-                    // 마지막 글자가 한글이 아닌 경우 비조합 문자열로 판단한다.
+                    // 커밋 대상 문자열 중 마지막 문자가 한글이 아닌 경우 비조합 문자로 판단한다.
                     let lastChar = String(recentCommitString.last!)
                     if lastChar.range(of: "[ㄱ-ㅎㅏ-ㅣ가-힣]", options: .regularExpression) == nil {
-                        _composedString = lastChar
-                        _commitString.append(String(recentCommitString.dropLast()))
+                        // 이 때, 마지막 문자가 입력기의 처리를 거치지 않은 것과 동일한 경우에는 deferred 모드를 사용하지 않는다.
+                        if lastChar == string {
+                            _commitString.append(recentCommitString)
+                            return .processed
+                        } else {
+                            _composedString = lastChar
+                            _commitString.append(String(recentCommitString.dropLast()))
+                        }
                     } else {
                         _commitString.append(recentCommitString)
                     }

--- a/OSXCore/SystemConfigurationWatcher.swift
+++ b/OSXCore/SystemConfigurationWatcher.swift
@@ -25,8 +25,8 @@ public class SystemConfigurationWatcher {
 
         let stream = FSEventStream.create(paths: [SystemConfigurationWatcher.globalPreferencesPath], eventId: FSEventStream.EventIdSinceNow, latancy: 5.0, flags: FSEventStream.CreateFlag.fileEvents) {
             [weak self] _, _ in
-                NSLog("Reloading system configuration by watcher")
-                self?.reloadConfiguration()
+            NSLog("Reloading system configuration by watcher")
+            self?.reloadConfiguration()
         }!
         stream.schedule(runLoop: .current, mode: .default)
         stream.start()

--- a/Preferences/Base.lproj/Preferences.xib
+++ b/Preferences/Base.lproj/Preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,7 +17,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="176" y="100" width="400" height="918"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="944"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="415" height="918"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -29,13 +29,13 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <view translatesAutoresizingMaskIntoConstraints="NO" id="Mwx-RP-qRv">
-                                    <rect key="frame" x="0.0" y="-56" width="415" height="974"/>
+                                    <rect key="frame" x="0.0" y="-81" width="415" height="999"/>
                                     <subviews>
                                         <stackView distribution="fillEqually" orientation="vertical" alignment="leading" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kLe-bm-FOO">
-                                            <rect key="frame" x="20" y="16" width="375" height="942"/>
+                                            <rect key="frame" x="20" y="16" width="375" height="967"/>
                                             <subviews>
                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g8D-VJ-ONL">
-                                                    <rect key="frame" x="0.0" y="797" width="375" height="145"/>
+                                                    <rect key="frame" x="0.0" y="822" width="375" height="145"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a8y-l9-yXh">
                                                             <rect key="frame" x="-2" y="129" width="90" height="16"/>
@@ -207,7 +207,7 @@
                                                     </customSpacing>
                                                 </stackView>
                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Td-o5-z1h">
-                                                    <rect key="frame" x="0.0" y="380" width="375" height="397"/>
+                                                    <rect key="frame" x="0.0" y="405" width="375" height="397"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DRr-ZG-wMG">
                                                             <rect key="frame" x="-2" y="381" width="101" height="16"/>
@@ -353,7 +353,7 @@ PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 �
                                                     </customSpacing>
                                                 </stackView>
                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zYw-Lc-Fgh">
-                                                    <rect key="frame" x="0.0" y="286" width="327" height="74"/>
+                                                    <rect key="frame" x="0.0" y="311" width="327" height="74"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dCm-f8-tKJ">
                                                             <rect key="frame" x="-2" y="58" width="101" height="16"/>
@@ -375,7 +375,7 @@ PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 �
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="crR-nL-R9N" userLabel="기본 키보드 레이아웃 Combo Box">
-                                                                    <rect key="frame" x="167" y="-4" width="163" height="26"/>
+                                                                    <rect key="frame" x="166" y="-2" width="164" height="23"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="160" id="G3O-6L-dgF"/>
                                                                         <constraint firstAttribute="height" constant="20" id="igh-sw-xvN"/>
@@ -425,10 +425,10 @@ PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 �
                                                     </customSpacing>
                                                 </stackView>
                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zbm-lz-J9a">
-                                                    <rect key="frame" x="0.0" y="84" width="307" height="182"/>
+                                                    <rect key="frame" x="0.0" y="84" width="307" height="207"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yjR-ur-FpL">
-                                                            <rect key="frame" x="-2" y="166" width="90" height="16"/>
+                                                            <rect key="frame" x="-2" y="191" width="90" height="16"/>
                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="한글 입력기 설정" id="HIp-u9-CIf">
                                                                 <font key="font" metaFont="systemBold"/>
                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -436,7 +436,7 @@ PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 �
                                                             </textFieldCell>
                                                         </textField>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JYx-Sc-lao">
-                                                            <rect key="frame" x="-2" y="138" width="288" height="18"/>
+                                                            <rect key="frame" x="-2" y="163" width="288" height="18"/>
                                                             <buttonCell key="cell" type="check" title="한글 입력기일 때 역따옴표(`)로 원화 기호(₩) 입력" bezelStyle="regularSquare" imagePosition="left" inset="2" id="2iT-lY-Scx" userLabel="한글 입력기일 때 역따옴표(`)로 원화 기호(₩) 입력">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -446,7 +446,7 @@ PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 �
                                                             </connections>
                                                         </button>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DXg-Ha-7zY">
-                                                            <rect key="frame" x="-2" y="111" width="234" height="18"/>
+                                                            <rect key="frame" x="-2" y="136" width="234" height="18"/>
                                                             <buttonCell key="cell" type="check" title="완성되지 않은 낱자 자동 교정 (모아치기)" bezelStyle="regularSquare" imagePosition="left" inset="2" id="HZu-6J-gbz">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -456,13 +456,23 @@ PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 �
                                                             </connections>
                                                         </button>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AHr-Ou-hBi">
-                                                            <rect key="frame" x="-2" y="84" width="309" height="18"/>
+                                                            <rect key="frame" x="-2" y="109" width="309" height="18"/>
                                                             <buttonCell key="cell" type="check" title="두벌식 초성 조합 중에도 종성 결합 허용 (MS윈도 호환)" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Phf-eg-t0A">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
                                                             </buttonCell>
                                                             <connections>
                                                                 <action selector="hangulNonChoseongCombinationValueChanged:" target="DMm-2g-KCR" id="RYe-GQ-ycc"/>
+                                                            </connections>
+                                                        </button>
+                                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="f9c-IQ-QKY">
+                                                            <rect key="frame" x="-2" y="83" width="257" height="18"/>
+                                                            <buttonCell key="cell" type="check" title="모든 글자를 조합중인 글자로 취급 (JDK 호환)" bezelStyle="regularSquare" imagePosition="left" inset="2" id="J0M-iD-R8Y">
+                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                <font key="font" size="13" name=".AppleSDGothicNeoI-Regular"/>
+                                                            </buttonCell>
+                                                            <connections>
+                                                                <action selector="hangulJDKCompatibleValueChanged:" target="DMm-2g-KCR" id="QTw-vh-Z6k"/>
                                                             </connections>
                                                         </button>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JOz-3z-VAl" userLabel="Strict Combination">
@@ -534,8 +544,10 @@ PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 �
                                                         <integer value="1000"/>
                                                         <integer value="1000"/>
                                                         <integer value="1000"/>
+                                                        <integer value="1000"/>
                                                     </visibilityPriorities>
                                                     <customSpacing>
+                                                        <real value="3.4028234663852886e+38"/>
                                                         <real value="3.4028234663852886e+38"/>
                                                         <real value="3.4028234663852886e+38"/>
                                                         <real value="3.4028234663852886e+38"/>
@@ -594,7 +606,7 @@ PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 �
                                                     </customSpacing>
                                                 </stackView>
                                                 <button hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1p7-M2-qsA">
-                                                    <rect key="frame" x="-7" y="915" width="83" height="32"/>
+                                                    <rect key="frame" x="-7" y="940" width="83" height="32"/>
                                                     <buttonCell key="cell" type="push" title="DEBUG!" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="sGP-Ih-dUD">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                         <font key="font" metaFont="system"/>
@@ -649,7 +661,7 @@ PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 �
                             <rect key="frame" x="0.0" y="903" width="414" height="15"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
-                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="E1U-9N-bFJ">
+                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="0.69135802469135799" horizontal="NO" id="E1U-9N-bFJ">
                             <rect key="frame" x="399" y="0.0" width="16" height="918"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
@@ -669,6 +681,7 @@ PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 �
                 <outlet property="debugButton" destination="1p7-M2-qsA" id="YQp-QQ-dbE"/>
                 <outlet property="hangulAutoReorderButton" destination="DXg-Ha-7zY" id="3qx-dc-nRf"/>
                 <outlet property="hangulForceStrictCombinationRuleButton" destination="JOz-3z-VAl" id="9Gi-l9-DbM"/>
+                <outlet property="hangulJDKCompatibleButton" destination="f9c-IQ-QKY" id="DnX-Jm-kHp"/>
                 <outlet property="hangulNonChoseongCombinationButton" destination="AHr-Ou-hBi" id="A1C-aF-9IN"/>
                 <outlet property="hangulWonCurrencySymbolForBackQuoteButton" destination="JYx-Sc-lao" id="5Kn-cE-sMA"/>
                 <outlet property="inputModeEnglishShortcutView" destination="fCD-Cp-FQV" id="i8N-tR-KEH"/>

--- a/Preferences/Base.lproj/Preferences.xib
+++ b/Preferences/Base.lproj/Preferences.xib
@@ -472,7 +472,7 @@ PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 �
                                                                 <font key="font" size="13" name=".AppleSDGothicNeoI-Regular"/>
                                                             </buttonCell>
                                                             <connections>
-                                                                <action selector="hangulJDKCompatibleValueChanged:" target="DMm-2g-KCR" id="QTw-vh-Z6k"/>
+                                                                <action selector="hangulDeferredSymbolCommitValueChanged:" target="DMm-2g-KCR" id="QTw-vh-Z6k"/>
                                                             </connections>
                                                         </button>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JOz-3z-VAl" userLabel="Strict Combination">
@@ -681,7 +681,7 @@ PC처럼 오른쪽 커맨드 또는 옵션 키 등으로 언어 전환을 할 �
                 <outlet property="debugButton" destination="1p7-M2-qsA" id="YQp-QQ-dbE"/>
                 <outlet property="hangulAutoReorderButton" destination="DXg-Ha-7zY" id="3qx-dc-nRf"/>
                 <outlet property="hangulForceStrictCombinationRuleButton" destination="JOz-3z-VAl" id="9Gi-l9-DbM"/>
-                <outlet property="hangulJDKCompatibleButton" destination="f9c-IQ-QKY" id="DnX-Jm-kHp"/>
+                <outlet property="hangulDeferredSymbolCommitButton" destination="f9c-IQ-QKY" id="DnX-Jm-kHp"/>
                 <outlet property="hangulNonChoseongCombinationButton" destination="AHr-Ou-hBi" id="A1C-aF-9IN"/>
                 <outlet property="hangulWonCurrencySymbolForBackQuoteButton" destination="JYx-Sc-lao" id="5Kn-cE-sMA"/>
                 <outlet property="inputModeEnglishShortcutView" destination="fCD-Cp-FQV" id="i8N-tR-KEH"/>

--- a/Preferences/PreferenceViewController.swift
+++ b/Preferences/PreferenceViewController.swift
@@ -30,7 +30,7 @@ final class PreferenceViewController: NSViewController {
     /// 두벌식 초성 조합 중에도 종성 결합 허용 (MS윈도 호환).
     @IBOutlet private var hangulNonChoseongCombinationButton: NSButton!
     /// 모든 글자를 조합중인 글자로 취급 (JDK 호환).
-    @IBOutlet private var hangulJDKCompatibleButton: NSButton!
+    @IBOutlet private var hangulDeferredSymbolCommitButton: NSButton!
     /// 세벌식 정석 강요.
     @IBOutlet private var hangulForceStrictCombinationRuleButton: NSButton!
     /// Esc 키로 로마자 자판으로 전환 (vi 모드).
@@ -85,7 +85,7 @@ final class PreferenceViewController: NSViewController {
         romanModeByEscapeKeyButton.state = isOn(configuration.romanModeByEscapeKey)
         hangulAutoReorderButton.state = isOn(configuration.hangulAutoReorder)
         hangulNonChoseongCombinationButton.state = isOn(configuration.hangulNonChoseongCombination)
-        hangulJDKCompatibleButton.state = isOn(configuration.hangulJDKCompatible)
+        hangulDeferredSymbolCommitButton.state = isOn(configuration.hangulDeferredSymbolCommit)
         hangulForceStrictCombinationRuleButton.state = isOn(configuration.hangulForceStrictCombinationRule)
         switch configuration.rightToggleKey {
         case kHIDUsage_KeyboardRightGUI:
@@ -203,8 +203,8 @@ final class PreferenceViewController: NSViewController {
         configuration.hangulNonChoseongCombination = sender.state == .on
     }
 
-    @IBAction private func hangulJDKCompatibleValueChanged(_ sender: NSButton) {
-        configuration.hangulJDKCompatible = sender.state == .on
+    @IBAction private func hangulDeferredSymbolCommitValueChanged(_ sender: NSButton) {
+        configuration.hangulDeferredSymbolCommit = sender.state == .on
     }
 
     @IBAction private func hangulForceStrictCombinationRuleValueChanged(_ sender: NSButton) {

--- a/Preferences/PreferenceViewController.swift
+++ b/Preferences/PreferenceViewController.swift
@@ -29,6 +29,8 @@ final class PreferenceViewController: NSViewController {
     @IBOutlet private var hangulAutoReorderButton: NSButton!
     /// 두벌식 초성 조합 중에도 종성 결합 허용 (MS윈도 호환).
     @IBOutlet private var hangulNonChoseongCombinationButton: NSButton!
+    /// 모든 글자를 조합중인 글자로 취급 (JDK 호환).
+    @IBOutlet private var hangulJDKCompatibleButton: NSButton!
     /// 세벌식 정석 강요.
     @IBOutlet private var hangulForceStrictCombinationRuleButton: NSButton!
     /// Esc 키로 로마자 자판으로 전환 (vi 모드).
@@ -83,6 +85,7 @@ final class PreferenceViewController: NSViewController {
         romanModeByEscapeKeyButton.state = isOn(configuration.romanModeByEscapeKey)
         hangulAutoReorderButton.state = isOn(configuration.hangulAutoReorder)
         hangulNonChoseongCombinationButton.state = isOn(configuration.hangulNonChoseongCombination)
+        hangulJDKCompatibleButton.state = isOn(configuration.hangulJDKCompatible)
         hangulForceStrictCombinationRuleButton.state = isOn(configuration.hangulForceStrictCombinationRule)
         switch configuration.rightToggleKey {
         case kHIDUsage_KeyboardRightGUI:
@@ -198,6 +201,10 @@ final class PreferenceViewController: NSViewController {
 
     @IBAction private func hangulNonChoseongCombinationValueChanged(_ sender: NSButton) {
         configuration.hangulNonChoseongCombination = sender.state == .on
+    }
+
+    @IBAction private func hangulJDKCompatibleValueChanged(_ sender: NSButton) {
+        configuration.hangulJDKCompatible = sender.state == .on
     }
 
     @IBAction private func hangulForceStrictCombinationRuleValueChanged(_ sender: NSButton) {


### PR DESCRIPTION
비 조합 문자열도 조합 중인 것으로 취급하여 Jetbrains IDE에 호환되도록 하는 호환 레이어를 추가했습니다.

<img width="316" alt="image" src="https://user-images.githubusercontent.com/763152/203357016-30a613fc-813f-4ac2-a73d-93219bb45baa.png">
환경설정에서 모든 글자를 조합중인 글자로 취급 (JDK 호환) 옵션을 켜면 활성화되며, AppCode에서 정상 동작하는 것을 확인하였습니다.

부작용으로, 터미널류의 앱에서 비 조합 문자열을 입력 중에 엔터를 누를 경우에도 바로 엔터가 입력되지 않고 조합 종료 상태가 되는 문제가 발생합니다.