### PR TITLE
#149 JDK 호환 모드에서 영문 문자판이 쿼티가 아닌 배열일 경우의 문제 수정

### DIFF
--- a/OSXCore/HangulComposer.swift
+++ b/OSXCore/HangulComposer.swift
@@ -232,10 +232,11 @@ final class HangulComposer: NSObject, Composer {
                     // 커밋 대상 문자열 중 마지막 문자가 한글이 아닌 경우 비조합 문자로 판단한다.
                     let lastChar = String(recentCommitString.last!)
                     if lastChar.range(of: "[ㄱ-ㅎㅏ-ㅣ가-힣]", options: .regularExpression) == nil {
-                        // 이 때, 마지막 문자가 입력기의 처리를 거치지 않은 것과 동일한 경우에는 deferred 모드를 사용하지 않는다.
-                        if lastChar == string {
-                            _commitString.append(recentCommitString)
-                            return .processed
+                        // 이 때, 마지막 문자가 입력기의 처리를 거치지 않은 것과 동일한 경우에는 입력기를 거치지 않고 결과를 처리하도록 한다.
+                        // 영문 자판마다 문자 배열의 차이가 있으므로, 해당 코드는 영문 자판이 ABC일때만 동작하도록 한다.
+                        if lastChar == string, Configuration.shared.overridingKeyboardName == "com.apple.keylayout.ABC" {
+                            _commitString.append(String(recentCommitString.dropLast()))
+                            return InputResult(processed: false, action: .cancel)
                         } else {
                             _composedString = lastChar
                             _commitString.append(String(recentCommitString.dropLast()))


### PR DESCRIPTION
한글 키보드에서 입력된 문자가 쿼티의 해당 키 문자와 동일할 경우 기본 입력기에 처리를 넘기고,
자판마다 특수문자의 배치가 다르기 때문에 드보락 등의 비-쿼티 레이아웃의 경우 입력된 문자가 쿼티 키보드의 배치와 동일한지와 무관하게 항상 조합 모드로 처리되도록 함

이 수정은 Jetbrains IDE의 호환성만이 아니라

JDK 호환 모드를 켰을 때
#822 #839 크로미엄에서 블럭이 설정된 문자의 수정 문제,
#819 크로미엄에서 일부 웹 사이트에서 숫자가 정상적으로 입력되지 않는 문제

등을 함께 개선합니다.

문자가 조합 상태일 경우 동작이 특이한 어플리케이션(터미널 등)이 있기 때문에 기본 옵션으로 두기는 어려울 것 같지만, 임시방편적으로나마 도움을 받을 수 있는 사람들이 있을 것으로 보입니다.