### PR TITLE
Chromium 호환성 문제 수정

### DIFF
--- a/OSXCore/InputReceiver.swift
+++ b/OSXCore/InputReceiver.swift
@@ -172,7 +172,7 @@ extension InputReceiver { // IMKServerInput
         dlog(DEBUG_LOGGING, "LOGGING::COMMIT::%lu:%lu:%@", range.location, range.length, commitString)
         // NSLog("range1 \(range)")글
         if range.length == 0 {
-            range = NSRange(location: NSNotFound, length: NSNotFound)
+            range = NSRange(location: NSNotFound, length: 0)
         }
         // NSLog("commit \(commitString) to \(range)")
         controller.client().insertText(commitString, replacementRange: range)

--- a/OSXCore/InputReceiver.swift
+++ b/OSXCore/InputReceiver.swift
@@ -172,12 +172,7 @@ extension InputReceiver { // IMKServerInput
         dlog(DEBUG_LOGGING, "LOGGING::COMMIT::%lu:%lu:%@", range.location, range.length, commitString)
         // NSLog("range1 \(range)")글
         if range.length == 0 {
-            range = sender.selectedRange()
-        }
-        // NSLog("range2 \(range)")
-        if range.length == 0 {
-            // 일부 프로그램이 길이가 0인 치환을 잘 처리하지 못하므로 특별히 처리한다
-            range = NSRange(location: NSNotFound, length: 0)
+            range = NSRange(location: NSNotFound, length: NSNotFound)
         }
         // NSLog("commit \(commitString) to \(range)")
         controller.client().insertText(commitString, replacementRange: range)


### PR DESCRIPTION
chromium 기반 브라우저 및 일렉트론 등으로 개발된 소프트웨어를 이용할 때, 일부 상황에서 숫자 등의 비 조합 문자들이 정상적으로 입력되지 않던 문제를 수정하는 패치입니다.
#825 #822 #819 #790 등에 영향을 줍니다.