### PR TITLE
#853 세벌식 이중모음 정석 구현을 위한 키 배열 추가

### DIFF
--- a/Gureum.xcodeproj/project.pbxproj
+++ b/Gureum.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		38EE977619FFD65600AD19B8 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38EE977519FFD65600AD19B8 /* Carbon.framework */; };
 		38F85961215BD27000CD80AE /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F85960215BD27000CD80AE /* main.swift */; };
 		38F85969215BF4BA00CD80AE /* Preferences.prefPane in Resources */ = {isa = PBXBuildFile; fileRef = 382E68641A1314D900031D1D /* Preferences.prefPane */; };
+		5F9C0129BE6142FE4D4D9CDB /* hangul-combination-3fs.xml in Resources */ = {isa = PBXBuildFile; fileRef = 5F9C0E22FD6549C16CC80600 /* hangul-combination-3fs.xml */; };
 		80383E6D2161F0D300FC5FB6 /* hangul-keyboard-3-2012.xml in Copy Keyboards Files */ = {isa = PBXBuildFile; fileRef = 80383E6A2161F0D300FC5FB6 /* hangul-keyboard-3-2012.xml */; };
 		80383E6E2161F0D300FC5FB6 /* hangul-keyboard-3-2011.xml in Copy Keyboards Files */ = {isa = PBXBuildFile; fileRef = 80383E6B2161F0D300FC5FB6 /* hangul-keyboard-3-2011.xml */; };
 		80383E6F2161F0D300FC5FB6 /* hangul-combination-3p.xml in Copy Keyboards Files */ = {isa = PBXBuildFile; fileRef = 80383E6C2161F0D300FC5FB6 /* hangul-combination-3p.xml */; };
@@ -126,6 +127,7 @@
 		CE21AE10280B0B2200B54371 /* SwiftUp in Frameworks */ = {isa = PBXBuildFile; productRef = CE21AE0F280B0B2200B54371 /* SwiftUp */; };
 		CE31CC0A28109975004659B0 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = CE31CC0928109975004659B0 /* FirebaseCrashlytics */; };
 		CE31CC0D28109B95004659B0 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CE31CC0C28109B95004659B0 /* GoogleService-Info.plist */; };
+		D98806252931170A0073EF2F /* hangul-combination-3fs.xml in Copy Keyboards Files */ = {isa = PBXBuildFile; fileRef = 5F9C0E22FD6549C16CC80600 /* hangul-combination-3fs.xml */; };
 		E5A0EA0A2139098800D4AD69 /* GureumAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A0EA092139098800D4AD69 /* GureumAppDelegate.swift */; };
 		E5ED2DE4213030B700BD9B13 /* GureumMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5ED2DE3213030B700BD9B13 /* GureumMenu.swift */; };
 /* End PBXBuildFile section */
@@ -239,6 +241,7 @@
 			dstPath = Hangul.framework/Resources/keyboards;
 			dstSubfolderSpec = 16;
 			files = (
+				D98806252931170A0073EF2F /* hangul-combination-3fs.xml in Copy Keyboards Files */,
 				80A02B24217E1AA90018E658 /* hangul-keyboard-2y-full.xml in Copy Keyboards Files */,
 				80A02B25217E1AA90018E658 /* hangul-keyboard-2-full.xml in Copy Keyboards Files */,
 				80383E6D2161F0D300FC5FB6 /* hangul-keyboard-3-2012.xml in Copy Keyboards Files */,
@@ -374,6 +377,7 @@
 		38F85960215BD27000CD80AE /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		38F85964215BEA3800CD80AE /* PreferencePanes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PreferencePanes.framework; path = System/Library/Frameworks/PreferencePanes.framework; sourceTree = SDKROOT; };
 		38FA220114233FD900444D67 /* Hangul.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Hangul.xcodeproj; path = "../libhangul-objc/Hangul.xcodeproj"; sourceTree = "<group>"; };
+		5F9C0E22FD6549C16CC80600 /* hangul-combination-3fs.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "hangul-combination-3fs.xml"; sourceTree = "<group>"; };
 		80383E6A2161F0D300FC5FB6 /* hangul-keyboard-3-2012.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "hangul-keyboard-3-2012.xml"; sourceTree = "<group>"; };
 		80383E6B2161F0D300FC5FB6 /* hangul-keyboard-3-2011.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "hangul-keyboard-3-2011.xml"; sourceTree = "<group>"; };
 		80383E6C2161F0D300FC5FB6 /* hangul-combination-3p.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "hangul-combination-3p.xml"; sourceTree = "<group>"; };
@@ -554,6 +558,7 @@
 				3835B5011F5DAA7100896BEC /* hangul-keyboard-3y.xml */,
 				3835B5021F5DAA7100896BEC /* hangul-keyboard-ahn.xml */,
 				3835B5031F5DAA7100896BEC /* hangul-keyboard-ro.xml */,
+				5F9C0E22FD6549C16CC80600 /* hangul-combination-3fs.xml */,
 			);
 			path = keyboards;
 			sourceTree = "<group>";
@@ -995,6 +1000,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5F9C0129BE6142FE4D4D9CDB /* hangul-combination-3fs.xml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OSXCore/data/keyboards/hangul-combination-3fs.xml
+++ b/OSXCore/data/keyboards/hangul-combination-3fs.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<combination id="0">
+    <item first="0x1100" second="0x1100" result="0x1101"/>  <!-- ᄀ   + ᄀ   → ᄁ  -->
+    <item first="0x1103" second="0x1103" result="0x1104"/>  <!-- ᄃ   + ᄃ   → ᄄ  -->
+    <item first="0x1107" second="0x1107" result="0x1108"/>  <!-- ᄇ   + ᄇ   → ᄈ  -->
+    <item first="0x1109" second="0x1109" result="0x110a"/>  <!-- ᄉ   + ᄉ   → ᄊ  -->
+    <item first="0x110c" second="0x110c" result="0x110d"/>  <!-- ᄌ   + ᄌ   → ᄍ  -->
+    <item first="0xe069" second="0x1161" result="0x116a"/>  <!-- ᅩ   + ᅡ   → ᅪ  -->
+    <item first="0x1161" second="0xe069" result="0x116a"/>  <!-- ᅩ   + ᅡ   → ᅪ  -->
+    <item first="0xe069" second="0x1162" result="0x116b"/>  <!-- ᅩ   + ᅢ   → ᅫ  -->
+    <item first="0x1162" second="0xe069" result="0x116b"/>  <!-- ᅩ   + ᅢ   → ᅫ  -->
+    <item first="0xe069" second="0x1175" result="0x116c"/>  <!-- ᅩ   + ᅵ   → ᅬ  -->
+    <item first="0x1175" second="0xe069" result="0x116c"/>  <!-- ᅩ   + ᅵ   → ᅬ  -->
+    <item first="0xe06e" second="0x1165" result="0x116f"/>  <!-- ᅮ   + ᅥ   → ᅯ  -->
+    <item first="0x1165" second="0xe06e" result="0x116f"/>  <!-- ᅮ   + ᅥ   → ᅯ  -->
+    <item first="0xe06e" second="0x1166" result="0x1170"/>  <!-- ᅮ   + ᅦ   → ᅰ  -->
+    <item first="0x1166" second="0xe06e" result="0x1170"/>  <!-- ᅮ   + ᅦ   → ᅰ  -->
+    <item first="0xe06e" second="0x1175" result="0x1171"/>  <!-- ᅮ   + ᅵ   → ᅱ  -->
+    <item first="0x1175" second="0xe06e" result="0x1171"/>  <!-- ᅮ   + ᅵ   → ᅱ  -->
+</combination>

--- a/OSXCore/data/keyboards/hangul-keyboard-3fs.xml
+++ b/OSXCore/data/keyboards/hangul-keyboard-3fs.xml
@@ -18,7 +18,7 @@
         <item key="0x2c" value="0x002c"/>  <!-- , → ,  -->
         <item key="0x2d" value="0x0029"/>  <!-- - → )  -->
         <item key="0x2e" value="0x002e"/>  <!-- . → .  -->
-        <item key="0x2f" value="0x1169"/>  <!-- / → ᅟᅩ -->
+        <item key="0x2f" value="0xe069"/>  <!-- / → ᅟᅩ (이중모음용) -->
         <item key="0x30" value="0x110f"/>  <!-- 0 → ᄏᅠ -->
         <item key="0x31" value="0x11c2"/>  <!-- 1 → ᅟᅠᇂ -->
         <item key="0x32" value="0x11bb"/>  <!-- 2 → ᅟᅠᆻ -->
@@ -28,7 +28,7 @@
         <item key="0x36" value="0x1163"/>  <!-- 6 → ᅟᅣ -->
         <item key="0x37" value="0x1168"/>  <!-- 7 → ᅟᅨ -->
         <item key="0x38" value="0x1174"/>  <!-- 8 → ᅟᅴ -->
-        <item key="0x39" value="0x116e"/>  <!-- 9 → ᅟᅮ -->
+        <item key="0x39" value="0xe06e"/>  <!-- 9 → ᅟᅮ (이중모음용) -->
         <item key="0x3a" value="0x0034"/>  <!-- : → 4  -->
         <item key="0x3b" value="0x1107"/>  <!-- ; → ᄇᅠ -->
         <item key="0x3c" value="0x002c"/>  <!-- < → ,  -->
@@ -100,6 +100,6 @@
         <item key="0x7e" value="0x203b"/>  <!-- ~ → ※ -->
     </map>
 
-    <include file="hangul-combination-3f.xml"/>
+    <include file="hangul-combination-3fs.xml"/>
 
 </hangul-keyboard>


### PR DESCRIPTION
세벌식 정석 강요 기능을 켤 경우 이중모음 정석도 올바르게 동작하도록 만드는 키 배열을 추가합니다.
이 수정은 https://github.com/gureum/libhangul/pull/20 수정에 의존성이 있습니다.