### PR TITLE
fix: Caps Lock 언어 변경이 안되는 현상을 해결합니다

### DIFF
--- a/GureumTests/GureumTests.swift
+++ b/GureumTests/GureumTests.swift
@@ -96,6 +96,22 @@ class GureumTests: XCTestCase {
         }
     }
 
+    func testCapsLockLanguageSwitchCapableInfoPlist() {
+        let infoDictionary = Bundle.main.infoDictionary ?? [:]
+        XCTAssertEqual(infoDictionary["TICapsLockLanguageSwitchCapable"] as? Bool, true)
+
+        let componentInputModeDict = infoDictionary["ComponentInputModeDict"] as? [String: Any]
+        let inputModes = componentInputModeDict?["tsInputModeListKey"] as? [String: [String: Any]]
+        let missingCapableInputModes = inputModes?
+            .filter { $0.key.hasPrefix("org.youknowone.inputmethod.Gureum.") }
+            .compactMap { inputMode, properties in
+                (properties["TICapsLockLanguageSwitchCapable"] as? Bool) == true ? nil : inputMode
+            }
+            .sorted()
+
+        XCTAssertEqual(missingCapableInputModes, [])
+    }
+
     func testSearchEmoticonTable() {
         let bundle = Bundle(for: HGKeyboard.self)
         let path: String? = bundle.path(forResource: "emoji", ofType: "txt", inDirectory: "hanja")

--- a/OSX/Info.plist
+++ b/OSX/Info.plist
@@ -32,6 +32,8 @@
 				<string>org.youknowone.inputmethod.Gureum.system</string>
 				<key>TISIntendedLanguage</key>
 				<string>en</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>eng.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -53,6 +55,8 @@
 				<string>org.youknowone.inputmethod.Gureum.colemak</string>
 				<key>TISIntendedLanguage</key>
 				<string>en</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>eng.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -74,6 +78,8 @@
 				<string>org.youknowone.inputmethod.Gureum.dvorak</string>
 				<key>TISIntendedLanguage</key>
 				<string>en</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>eng.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -97,6 +103,8 @@
 				<string>org.youknowone.inputmethod.Gureum.han2</string>
 				<key>TISIntendedLanguage</key>
 				<string>ko</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>han2.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -118,6 +126,8 @@
 				<string>org.youknowone.inputmethod.Gureum.han2classic</string>
 				<key>TISIntendedLanguage</key>
 				<string>ko</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>han2.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -139,6 +149,8 @@
 				<string>org.youknowone.inputmethod.Gureum.han3-2011</string>
 				<key>TISIntendedLanguage</key>
 				<string>ko</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>han3.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -160,6 +172,8 @@
 				<string>org.youknowone.inputmethod.Gureum.han3-2012</string>
 				<key>TISIntendedLanguage</key>
 				<string>ko</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>han3.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -181,6 +195,8 @@
 				<string>org.youknowone.inputmethod.Gureum.han390</string>
 				<key>TISIntendedLanguage</key>
 				<string>ko</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>han3.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -202,6 +218,8 @@
 				<string>org.youknowone.inputmethod.Gureum.han3classic</string>
 				<key>TISIntendedLanguage</key>
 				<string>ko</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>han3.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -225,6 +243,8 @@
 				<string>org.youknowone.inputmethod.Gureum.han3final</string>
 				<key>TISIntendedLanguage</key>
 				<string>ko</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>han3.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -248,6 +268,8 @@
 				<string>org.youknowone.inputmethod.Gureum.han3finalnoshift</string>
 				<key>TISIntendedLanguage</key>
 				<string>ko</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>han3.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -271,6 +293,8 @@
 				<string>org.youknowone.inputmethod.Gureum.han3layout2</string>
 				<key>TISIntendedLanguage</key>
 				<string>ko</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>han3.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -292,6 +316,8 @@
 				<string>org.youknowone.inputmethod.Gureum.han3noshift</string>
 				<key>TISIntendedLanguage</key>
 				<string>ko</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>han3.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -313,6 +339,8 @@
 				<string>org.youknowone.inputmethod.Gureum.hanahnmatae</string>
 				<key>TISIntendedLanguage</key>
 				<string>ko</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>han.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -334,6 +362,8 @@
 				<string>org.youknowone.inputmethod.Gureum.hanroman</string>
 				<key>TISIntendedLanguage</key>
 				<string>ko</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>hanroman.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -357,6 +387,8 @@
 				<string>org.youknowone.inputmethod.Gureum.qwerty</string>
 				<key>TISIntendedLanguage</key>
 				<string>en</string>
+				<key>TICapsLockLanguageSwitchCapable</key>
+				<true/>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>qwerty.png</string>
 				<key>tsInputModeDefaultStateKey</key>
@@ -432,6 +464,8 @@
 	<string>org.youknowone.inputmethod.Korean</string>
 	<key>TISIntendedLanguage</key>
 	<string>ko</string>
+	<key>TICapsLockLanguageSwitchCapable</key>
+	<true/>
 	<key>tsInputMethodCharacterRepertoireKey</key>
 	<array>
 		<string>Latn</string>


### PR DESCRIPTION
close #883 #837

macOS는 입력 소스가 `Caps Lock` 언어 전환 대상이 되려면 입력기 번들의 `Info.plist`에 관련 capability가 명시되어 있어야 합니다.

현재 구름입력기의 `OSX/Info.plist`에는 이 capability가 선언되어 있지 않아, 시스템 설정에서 `Caps Lock`을 한/영 전환 용도로 사용하더라도 구름입력기 입력 모드에서는 전환이 동작하지 않았습니다.

Caps Lock으로 입력 소스 전환이 가능하도록 구름입력기의 입력 모드 plist 설정 추가했습니다.

- Apple 문서: `TICapsLockLanguageSwitchCapable`
