### PR TITLE
cli 도구로 한영, 한자 이벤트를 트리거

### DIFF
--- a/Gureum.xcodeproj/project.pbxproj
+++ b/Gureum.xcodeproj/project.pbxproj
@@ -710,6 +710,7 @@
 				38162DF0141263270077AA2D /* Frameworks */,
 				38162DF1141263270077AA2D /* Resources */,
 				387736EB1423561F00DE50D6 /* Copy Frameworks */,
+				388186D521EB3FFF004B7FDB /* Compile Gureum CLI */,
 				CE31CC0B281099D9004659B0 /* Run Crashlytics */,
 			);
 			buildRules = (
@@ -1012,6 +1013,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		388186D521EB3FFF004B7FDB /* Compile Gureum CLI */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/tools/gureum-cli.swift",
+			);
+			name = "Compile Gureum CLI";
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(PRODUCT_NAME).app/Contents/MacOS/gureum-cli",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "swiftc -O \"${SRCROOT}/tools/gureum-cli.swift\" -o \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}.app/Contents/MacOS/gureum-cli\"\n";
+		};
 		382AF2C12156269F00701F90 /* Generate Version.xcconfig */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/OSXCore/InputController.swift
+++ b/OSXCore/InputController.swift
@@ -211,6 +211,18 @@ extension InputController {  // IMKStateSetting
   public override func activateServer(_ sender: Any!) {
     dlog(true, "server activated")
     super.activateServer(sender)
+
+    DistributedNotificationCenter.default().removeObserver(
+      self,
+      name: NSNotification.Name("org.youknowone.gureum.layoutEvent"),
+      object: nil
+    )
+    DistributedNotificationCenter.default().addObserver(
+      self,
+      selector: #selector(handleLayoutEventNotification(_:)),
+      name: NSNotification.Name("org.youknowone.gureum.layoutEvent"),
+      object: nil
+    )
   }
 
   public override func deactivateServer(_ sender: Any!) {
@@ -218,7 +230,35 @@ extension InputController {  // IMKStateSetting
     if responds(to: #selector(commitComposition(_:))) {
       self.commitComposition(sender)
     }
+    DistributedNotificationCenter.default().removeObserver(
+      self,
+      name: NSNotification.Name("org.youknowone.gureum.layoutEvent"),
+      object: nil
+    )
     super.deactivateServer(sender)
+  }
+
+  @objc public func handleLayoutEventNotification(_ notification: Notification) {
+    dlog(true, "handleLayoutEventNotification received: \(notification)")
+    guard let client = client() as? (IMKTextInput & IMKUnicodeTextInput) else {
+      dlog(true, "handleLayoutEventNotification: active client is nil or not matching protocol")
+      return
+    }
+
+    let action = notification.userInfo?["action"] as? String ?? "toggle"
+    let changeLayout: ChangeLayout
+    switch action {
+    case "hangul":
+      changeLayout = .hangul
+    case "roman":
+      changeLayout = .roman
+    case "hanja":
+      changeLayout = .search
+    default:
+      changeLayout = .toggle
+    }
+
+    _ = receiver.input(event: .changeLayout(changeLayout, true), client: client)
   }
 }
 

--- a/OSXCore/InputController.swift
+++ b/OSXCore/InputController.swift
@@ -159,6 +159,10 @@ extension InputController {  // IMKServerInputHandleEvent
       let changed = lastFlags.symmetricDifference(event.modifierFlags)
       lastFlags = event.modifierFlags
 
+      if changed.contains(.command), event.modifierFlags.contains(.command) {
+        receiver.commitCompositionWithUnselect(client)
+      }
+
       if changed.contains(.capsLock), Configuration.shared.enableCapslockToToggleInputMode {
         if InputMethodServer.shared.io.capsLockTriggered {
           dlog(debugIOKitEvent, "controller detected capslock to change layout")

--- a/OSXCore/InputReceiver.swift
+++ b/OSXCore/InputReceiver.swift
@@ -62,16 +62,16 @@ public class InputReceiver: InputTextDelegate {
     modifiers flags: NSEvent.ModifierFlags,
     client sender: IMKTextInput & IMKUnicodeTextInput
   ) -> InputResult {
-    let selected = sender.selectedRange()
-    let marked = sender.markedRange()
-    if selected.location != marked.location {
-      //            dlog(debugLogging, "MISMATCHING: \(selected) \(marked)")
-      //            cancelComposition()
-      //            sender.setMarkedText("", selectionRange: NSRange(location: 0, length: 0), replacementRange: NSRange(location: selected.location, length: 0))
-      //
-      //            // commitComposition(sender)
-      //            marked = selected
-    }
+    //     let selected = sender.selectedRange()
+    //     let marked = sender.markedRange()
+    //     if selected.location != marked.location {
+    //       //            dlog(debugLogging, "MISMATCHING: \(selected) \(marked)")
+    //       //            cancelComposition()
+    //       //            sender.setMarkedText("", selectionRange: NSRange(location: 0, length: 0), replacementRange: NSRange(location: selected.location, length: 0))
+    //       //
+    //       //            // commitComposition(sender)
+    //       //            marked = selected
+    //     }
 
     // 입력기용 특수 커맨드 처리
     if let command = composer.filterCommand(keyCode: keyCode, modifiers: flags, client: sender) {

--- a/OSXCore/InputReceiver.swift
+++ b/OSXCore/InputReceiver.swift
@@ -203,6 +203,22 @@ extension InputReceiver {  // IMKServerInput
     return true
   }
 
+  func commitCompositionWithUnselect(_ sender: IMKTextInput & IMKUnicodeTextInput) {
+    let markedRange = sender.markedRange()
+    if markedRange.location == NSNotFound || markedRange.length == 0 {
+      return
+    }
+
+    let wasInputting = inputting
+    inputting = false
+    if commitCompositionEvent(sender) {
+      let caretRange = NSRange(location: markedRange.location + markedRange.length, length: 0)
+      sender.setMarkedText(
+        "", selectionRange: NSRange(location: 0, length: 0), replacementRange: caretRange)
+    }
+    inputting = wasInputting
+  }
+
   func updateCompositionEvent() {
     dlog(debugLogging, "LOGGING::EVENT::UPDATE")
     dlog(debugInputController, "** InputController -updateComposition")

--- a/tools/gureum-cli.swift
+++ b/tools/gureum-cli.swift
@@ -1,0 +1,69 @@
+#!/usr/bin/env swift
+import Foundation
+
+func printUsage() {
+    print("""
+    Gureum CLI Layout Controller
+    Usage:
+      gureum-cli [command]
+
+    Commands:
+      toggle   Toggle layout between Hangul and Roman (default)
+      hangul   Force switch to Hangul layout
+      roman    Force switch to Roman layout
+      hanja    Switch to Hanja (Search) layout
+      help     Show this help message
+      --silent Suppress success output
+    """)
+}
+
+let args = CommandLine.arguments
+var command = "toggle"
+var silent = false
+if args.count > 1 {
+    var idx = 1
+    while idx < args.count {
+        let arg = args[idx]
+        if arg == "--silent" {
+            silent = true
+        } else if arg.hasPrefix("-") {
+            // Ignore other flags for now
+        } else {
+            command = arg.lowercased()
+        }
+        idx += 1
+    }
+}
+
+let action: String
+switch command {
+case "toggle":
+    action = "toggle"
+case "hangul":
+    action = "hangul"
+case "roman":
+    action = "roman"
+case "hanja":
+    action = "hanja"
+case "help", "-h", "--help":
+    printUsage()
+    exit(0)
+default:
+    print("Unknown command: \(command)")
+    printUsage()
+    exit(1)
+}
+
+let notificationName = NSNotification.Name("org.youknowone.gureum.layoutEvent")
+let userInfo = ["action": action]
+
+DistributedNotificationCenter.default().postNotificationName(
+    notificationName,
+    object: nil,
+    userInfo: userInfo,
+    deliverImmediately: true
+)
+
+if !silent {
+    print("Successfully sent '\(action)' event to Gureum.")
+}


### PR DESCRIPTION
구현의 목적은 가상키보드를 통해 이벤트를 완벽히 제어하는 karabiner-elements 에 단축키 이벤트를 위임하기 위함입니다.

https://github.com/gureum/gureum/issues/921 요청했던것 antigravity 로 구현해 봤습니다.
Debug 빌드에서도 전환 속도가 충분히 빠르네요.
Release 에서 훨씬 쾌적할 것을 기대합니다.

이렇게 설정하면 iTerm2 에서 한영, 한자 단축키 변경이 자유롭고,
구름 입력기 외의 입력 소스 상태에서 한영키 두번으로 확정적으로 한글 상태가 되는 장점이 있습니다.

감사합니다.

```json
{
	"description": "구름 입력기 설정",
	"manipulators": [
		{
			"conditions": [
				{
					"input_sources": [{ "input_source_id": "org.youknowone.inputmethod.Gureum" }],
					"type": "input_source_if"
				}
			],
			"description": "한/영",
			"from": { "key_code": "right_command" },
			"to": [{ "shell_command": "/Library/Input\\ Methods/Gureum.app/Contents/MacOS/gureum-cli --silent toggle" }],
			"type": "basic"
		},
		{
			"conditions": [
				{
					"input_sources": [{ "input_source_id": "org.youknowone.inputmethod.Gureum" }],
					"type": "input_source_if"
				}
			],
			"description": "한자",
			"from": { "key_code": "right_option" },
			"to": [{ "shell_command": "/Library/Input\\ Methods/Gureum.app/Contents/MacOS/gureum-cli --silent hanja" }],
			"type": "basic"
		},
		{
			"conditions": [
				{
					"input_sources": [{ "input_source_id": "org.youknowone.inputmethod.Gureum" }],
					"type": "input_source_unless"
				}
			],
			"description": "구름 입력기가 아닌경우 구름 영문으로 전환",
			"from": { "key_code": "right_command" },
			"to": [{ "select_input_source": { "input_source_id": "org.youknowone.inputmethod.Gureum.system" } }],
			"type": "basic"
		}
	]
}
```

<img width="408" height="420" alt="image" src="https://github.com/user-attachments/assets/632ba9fb-6f22-42b4-a5d4-9f62fb324578" />
