### PR TITLE
fix: 입력창 이동 시 마지막 입력 모드 유지

### DIFF
--- a/GureumTests/GureumTests.swift
+++ b/GureumTests/GureumTests.swift
@@ -96,6 +96,34 @@ class GureumTests: XCTestCase {
         }
     }
 
+    func testComposerStartsWithLastInputMode() {
+        Configuration.shared.restoreLastInputModeOnActivate = true
+        Configuration.shared.lastInputMode = GureumInputSource.qwerty.rawValue
+        XCTAssertEqual(GureumInputSource.qwerty.rawValue, GureumComposer().inputMode)
+
+        Configuration.shared.lastInputMode = GureumInputSource.han3Final.rawValue
+        XCTAssertEqual(GureumInputSource.han3Final.rawValue, GureumComposer().inputMode)
+    }
+
+    func testComposerStartsWithLastRomanInputModeWhenRestoreLastInputModeDisabled() {
+        Configuration.shared.restoreLastInputModeOnActivate = false
+        Configuration.shared.lastInputMode = GureumInputSource.han3Final.rawValue
+        Configuration.shared.lastRomanInputMode = GureumInputSource.qwerty.rawValue
+
+        XCTAssertEqual(GureumInputSource.qwerty.rawValue, GureumComposer().inputMode)
+    }
+
+    func testSetValueDuringInitialRestoreKeepsPendingInputMode() {
+        Configuration.shared.restoreLastInputModeOnActivate = true
+        Configuration.shared.lastInputMode = GureumInputSource.qwerty.rawValue
+
+        let app = ModerateApp()
+        app.controller.setValue(GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
+
+        XCTAssertEqual(GureumInputSource.qwerty.rawValue, app.controller.receiver.composer.inputMode)
+        XCTAssertEqual(GureumInputSource.qwerty.rawValue, Configuration.shared.lastInputMode)
+    }
+
     func testCapsLockLanguageSwitchCapableInfoPlist() {
         let infoDictionary = Bundle.main.infoDictionary ?? [:]
         XCTAssertEqual(infoDictionary["TICapsLockLanguageSwitchCapable"] as? Bool, true)

--- a/OSXCore/Configuration.swift
+++ b/OSXCore/Configuration.swift
@@ -15,6 +15,10 @@ enum ConfigurationName {
     public static let lastHangulInputMode = "LastHangulInputMode"
     /// 마지막 로마자 입력 모드.
     public static let lastRomanInputMode = "LastRomanInputMode"
+    /// 마지막 입력 모드.
+    public static let lastInputMode = "LastInputMode"
+    /// 입력창 활성화 시 마지막 입력 모드 복원.
+    public static let restoreLastInputModeOnActivate = "RestoreLastInputModeOnActivate"
 
     /// 입력기 바꾸기 단축키.
     public static let inputModeExchangeKey = "InputModeExchangeKey"
@@ -89,6 +93,8 @@ public class Configuration: UserDefaults {
         register(defaults: [
             ConfigurationName.lastHangulInputMode: "org.youknowone.inputmethod.Gureum.han2",
             ConfigurationName.lastRomanInputMode: "org.youknowone.inputmethod.Gureum.qwerty",
+            ConfigurationName.lastInputMode: "org.youknowone.inputmethod.Gureum.han2",
+            ConfigurationName.restoreLastInputModeOnActivate: false,
 
             ConfigurationName.inputModeSearchKey: Configuration.convertShortcutToConfiguration((.return, .option)),
             ConfigurationName.optionKeyBehavior: 1,
@@ -134,6 +140,26 @@ public class Configuration: UserDefaults {
         }
         set {
             set(newValue, forKey: ConfigurationName.lastRomanInputMode)
+        }
+    }
+
+    /// 마지막 입력 모드.
+    public var lastInputMode: String {
+        get {
+            string(forKey: ConfigurationName.lastInputMode)!
+        }
+        set {
+            set(newValue, forKey: ConfigurationName.lastInputMode)
+        }
+    }
+
+    /// 입력창 활성화 시 마지막 입력 모드 복원.
+    public var restoreLastInputModeOnActivate: Bool {
+        get {
+            bool(forKey: ConfigurationName.restoreLastInputModeOnActivate)
+        }
+        set {
+            set(newValue, forKey: ConfigurationName.restoreLastInputModeOnActivate)
         }
     }
 

--- a/OSXCore/GureumComposer.swift
+++ b/OSXCore/GureumComposer.swift
@@ -82,8 +82,8 @@ final class GureumComposer: Composer {
 
     init() {
         romanComposer = systemRomanComposer
-        inputMode = Configuration.shared.lastRomanInputMode
-        delegate = romanComposer
+        let configuration = Configuration.shared
+        inputMode = configuration.restoreLastInputModeOnActivate ? configuration.lastInputMode : configuration.lastRomanInputMode
     }
 
     // MARK: Composer 프로토콜 구현
@@ -167,6 +167,7 @@ extension GureumComposer {
             }
 
             _inputMode = newValue
+            Configuration.shared.lastInputMode = newValue
         }
     }
 

--- a/OSXCore/InputController.swift
+++ b/OSXCore/InputController.swift
@@ -52,6 +52,8 @@ public class InputController: IMKInputController {
     var receiver: InputReceiver!
     var lastFlags = NSEvent.ModifierFlags(rawValue: 0)
     var updating = false
+    var pendingRestoreInputMode: String?
+    var pendingRestoreInputModeExpiresAt: Date?
 
     override init!(server: IMKServer, delegate: Any!, client inputClient: Any) {
         super.init(server: server, delegate: delegate, client: inputClient)
@@ -61,10 +63,17 @@ public class InputController: IMKInputController {
         dlog(DEBUG_INPUTCONTROLLER, "**** NEW INPUT CONTROLLER INIT **** WITH SERVER: \(server) / DELEGATE: \(String(describing: delegate)) / CLIENT: \(inputClient) \(inputClient.bundleIdentifier() ?? "nil")")
         assert(InputMethodServer.shared.server === server)
         receiver = InputReceiver(server: server, delegate: delegate, client: inputClient, controller: self)
+        beginPendingRestoreInputMode()
     }
 
     override init() {
         super.init()
+    }
+
+    func beginPendingRestoreInputMode() {
+        guard Configuration.shared.restoreLastInputModeOnActivate else { return }
+        pendingRestoreInputMode = Configuration.shared.lastInputMode
+        pendingRestoreInputModeExpiresAt = Date().addingTimeInterval(0.7)
     }
 
     override public func inputControllerWillClose() {
@@ -208,12 +217,43 @@ public extension InputController { // IMKStateSetting
     //! @brief 자판 전환을 감지한다.
     override func setValue(_ value: Any, forTag tag: Int, client sender: Any) {
         let client = asClient(sender)
+        if tag == kTextServiceInputModePropertyTag,
+           let value = value as? String,
+           let pendingInputMode = pendingRestoreInputMode,
+           (pendingRestoreInputModeExpiresAt ?? .distantPast) > Date(),
+           value != pendingInputMode
+        {
+            receiver.setValue(pendingInputMode, forTag: tag, client: client)
+            Configuration.shared.lastInputMode = pendingInputMode
+            (client as IMKTextInput).selectMode(pendingInputMode)
+            return
+        }
         receiver.setValue(value, forTag: tag, client: client)
     }
 
     override func activateServer(_ sender: Any!) {
         dlog(true, "server activated")
         super.activateServer(sender)
+        guard Configuration.shared.restoreLastInputModeOnActivate else { return }
+        beginPendingRestoreInputMode()
+        for delay in [0.0, 0.05, 0.2, 0.5] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.restoreLastInputModeOnActivateIfNeeded(sender)
+            }
+        }
+    }
+
+    func restoreLastInputModeOnActivateIfNeeded(_ sender: Any!) {
+        guard Configuration.shared.restoreLastInputModeOnActivate else {
+            pendingRestoreInputMode = nil
+            pendingRestoreInputModeExpiresAt = nil
+            return
+        }
+        let inputMode = pendingRestoreInputMode ?? Configuration.shared.lastInputMode
+        guard let receiver = receiver else { return }
+        guard receiver.composer.inputMode != inputMode else { return }
+        receiver.composer.inputMode = inputMode
+        (asClient(sender) as IMKTextInput).selectMode(inputMode)
     }
 
     override func deactivateServer(_ sender: Any!) {
@@ -297,6 +337,7 @@ public extension InputController { // IMKServerInput
         override public init(server: IMKServer, delegate: Any!, client: Any) {
             super.init()
             receiver = InputReceiver(server: server, delegate: delegate, client: client as! (IMKTextInput & IMKUnicodeTextInput), controller: self)
+            beginPendingRestoreInputMode()
         }
 
         func repoduceTextLog(_ text: String) throws {
@@ -403,8 +444,7 @@ public extension InputController { // IMKServerInput
 
         //! @brief 자판 전환을 감지한다.
         override func setValue(_ value: Any, forTag tag: Int, client sender: Any) {
-            let client = asClient(sender)
-            receiver.setValue(value, forTag: tag, client: client)
+            super.setValue(value, forTag: tag, client: sender)
         }
     }
 #endif


### PR DESCRIPTION
입력창을 새로 활성화할 때마다 구름 입력기가 한글 모드로 돌아가서, 마지막으로 선택한 입력 모드를 복원할 수 있도록 옵션을 추가했습니다.

관련 이슈: #882, #748

기본 동작은 바꾸지 않고, 아래 설정을 켠 경우에만 동작합니다.

```sh
defaults write org.youknowone.Gureum RestoreLastInputModeOnActivate -bool true
```

구현 내용은 다음과 같습니다.

- 기존 한글/로마자별 마지막 자판과 별도로 실제 마지막 입력 모드(`LastInputMode`)를 저장합니다.
- 새 입력 컨트롤러가 만들어지거나 입력창이 활성화될 때, 옵션이 켜져 있으면 마지막 입력 모드를 복원합니다.
- 활성화 직후 IMK가 한글 모드를 다시 전달하는 경우를 짧은 시간 동안 막아 저장된 모드가 덮어써지지 않도록 했습니다.

확인한 내용은 다음과 같습니다.

- 새로 추가한 입력 모드 복원 관련 테스트를 통과했습니다.
- 로컬 디버그 빌드를 설치해서 새 입력창으로 이동해도 쿼티 모드가 유지되는 것을 확인했습니다.
- 전체 `xcodebuild -project Gureum.xcodeproj -scheme OSX -configuration Debug build test`는 빌드 후 테스트 단계에서 기존 `GureumObjCTests testIPMDServerClientWrapper`가 로컬 IMK/TCC 환경 오류와 함께 실패했습니다.
- `swiftformat --lint OSXCore/ OSX/ GureumTests/ Preferences/ OSXTestApp/`는 SwiftFormat 0.61.1 기준으로 이번 변경과 무관한 기존 파일 포맷 차이를 보고했습니다.
