### PR TITLE
Switch code formatter to Apple swift-format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,15 +13,11 @@ jobs:
         with:
           check_together: 'yes'
           scandir: 'tools'
-  swiftformat:
-    runs-on: ubuntu-latest
+  swift-format:
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: Cyberbeni/install-swift-tool@v2
-        with:
-          url: https://github.com/nicklockwood/SwiftFormat
-          version: '*' # format: https://devhints.io/semver
-      - run: swiftformat --lint OSXCore/ OSX/ GureumTests/ Preferences/ OSXTestApp/
+      - run: swift format lint --strict --recursive OSXCore OSX GureumTests Preferences OSXTestApp
   build-and-test:
     runs-on: macos-latest
     steps:

--- a/GureumTests/GureumTests.swift
+++ b/GureumTests/GureumTests.swift
@@ -6,941 +6,1055 @@
 //  Copyright © 2018 youknowone.org. All rights reserved.
 //
 
-@testable import GureumCore
 import Hangul
 import InputMethodKit
 import XCTest
 
+@testable import GureumCore
+
 private var lastNotification: NSUserNotification!
 
 extension NSUserNotificationCenter {
-    func deliver(_ notification: NSUserNotification) {
-        lastNotification = notification
-    }
+  func deliver(_ notification: NSUserNotification) {
+    lastNotification = notification
+  }
 }
 
 class GureumTests: XCTestCase {
-    static let domainName = "org.youknowone.Gureum.test"
-    lazy var moderate: VirtualApp = ModerateApp()
-    // lazy var xcode: VirtualApp = XcodeApp()
-    lazy var terminal: VirtualApp! = nil
-    // lazy var terminal: VirtualApp = TerminalApp()
-    // lazy var greedy: VirtualApp = GreedyApp()
-    lazy var apps: [VirtualApp] = [moderate]
+  static let domainName = "org.youknowone.Gureum.test"
+  lazy var moderate: VirtualApp = ModerateApp()
+  // lazy var xcode: VirtualApp = XcodeApp()
+  lazy var terminal: VirtualApp! = nil
+  // lazy var terminal: VirtualApp = TerminalApp()
+  // lazy var greedy: VirtualApp = GreedyApp()
+  lazy var apps: [VirtualApp] = [moderate]
 
-    override class func setUp() {
-        Configuration.shared = Configuration(suiteName: "org.youknowone.Gureum.test")!
-        super.setUp()
+  override class func setUp() {
+    Configuration.shared = Configuration(suiteName: "org.youknowone.Gureum.test")!
+    super.setUp()
+  }
+
+  override class func tearDown() {
+    super.tearDown()
+  }
+
+  override func setUp() {
+    super.setUp()
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+
+    Configuration.shared.removePersistentDomain(forName: GureumTests.domainName)
+  }
+
+  override func tearDown() {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    super.tearDown()
+  }
+
+  func testPreferencePane() {
+    let path = Bundle.main.path(forResource: "Preferences", ofType: "prefPane")
+    let bundle = NSPrefPaneBundle(path: path)!
+    let loaded = bundle.instantiatePrefPaneObject()
+    XCTAssertTrue(loaded)
+  }
+
+  func testNotifyUpdate() {
+    let data = """
+      {
+          "version": "1.10.0",
+          "description": "Mojave 대응을 포함한 대형 업데이트",
+          "url": "https://github.com/gureum/gureum/releases/tag/1.10.0"
+      }
+      """.data(using: .utf8)
+    let update = try! JSONDecoder().decode(UpdateManager.UpdateInfo.self, from: data!)
+
+    let versionInfo = UpdateManager.VersionInfo(update: update, experimental: true)
+    UpdateManager.notifyUpdate(info: versionInfo)
+    XCTAssertEqual(
+      "최신 버전: 1.10.0 현재 버전: \(Bundle.main.version ?? "-")\nMojave 대응을 포함한 대형 업데이트",
+      lastNotification.informativeText)
+    XCTAssertEqual(
+      ["url": "https://github.com/gureum/gureum/releases/tag/1.10.0"],
+      lastNotification.userInfo as! [String: String])
+  }
+
+  func testLayoutChange() {
+    Configuration.shared.inputModeExchangeKey = Configuration.Shortcut(.space, .shift)
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        "org.youknowone.inputmethod.Gureum.qwerty", forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputFlags(.capsLock)
+
+      app.inputText(" ", key: .space, modifiers: .shift)
+      app.inputText(" ", key: .space, modifiers: .shift)
+      XCTAssertEqual("", app.client.string, "buffer: \(app.client.string), app: \(app)")
     }
+  }
 
-    override class func tearDown() {
-        super.tearDown()
+  func testLayoutChangeCommit() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        "org.youknowone.inputmethod.Gureum.han2", forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputKey(.ansiG)
+      XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      app.inputFlags(.capsLock)
+      XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string), app: \(app)")
     }
+  }
 
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+  func testCapsLockLanguageSwitchCapableInfoPlist() {
+    let infoDictionary = Bundle.main.infoDictionary ?? [:]
+    XCTAssertEqual(infoDictionary["TICapsLockLanguageSwitchCapable"] as? Bool, true)
 
-        Configuration.shared.removePersistentDomain(forName: GureumTests.domainName)
+    let componentInputModeDict = infoDictionary["ComponentInputModeDict"] as? [String: Any]
+    let inputModes = componentInputModeDict?["tsInputModeListKey"] as? [String: [String: Any]]
+    let missingCapableInputModes = inputModes?
+      .filter { $0.key.hasPrefix("org.youknowone.inputmethod.Gureum.") }
+      .compactMap { inputMode, properties in
+        (properties["TICapsLockLanguageSwitchCapable"] as? Bool) == true ? nil : inputMode
+      }
+      .sorted()
+
+    XCTAssertEqual(missingCapableInputModes, [])
+  }
+
+  func testSearchEmoticonTable() {
+    let bundle = Bundle(for: HGKeyboard.self)
+    let path: String? = bundle.path(forResource: "emoji", ofType: "txt", inDirectory: "hanja")
+    let table = HGHanjaTable(contentOfFile: path!)!
+    // 현재 5글자 이상만 가능
+    let list: HGHanjaList = table.hanjas(byPrefixSearching: "hushed") ?? HGHanjaList()
+    XCTAssert(list.count > 0)
+  }
+
+  func testCommandkeyAndControlkey() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.qwerty.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputKey(.ansiA, modifiers: .command)
+      app.inputKey(.ansiA, modifiers: .control)
+      XCTAssertEqual("", app.client.string, "")
+      XCTAssertEqual("", app.client.markedString(), "")
     }
+  }
 
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
+  func testCapslockRoman() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.qwerty.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputKey(.ansiM)
+      app.inputKey(.ansiR)
+      app.inputKey(.ansi2)
+      XCTAssertEqual("mr2", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.qwerty.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputKey(.ansiM, modifiers: .capsLock)
+      app.inputKey(.ansiR, modifiers: .capsLock)
+      app.inputKey(.ansi2, modifiers: .capsLock)
+      XCTAssertEqual("MR2", app.client.string, "buffer: \(app.client.string), app: \(app)")
     }
+  }
 
-    func testPreferencePane() {
-        let path = Bundle.main.path(forResource: "Preferences", ofType: "prefPane")
-        let bundle = NSPrefPaneBundle(path: path)!
-        let loaded = bundle.instantiatePrefPaneObject()
-        XCTAssertTrue(loaded)
+  func testHanjaSyllable() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han3Final.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputKey(.ansiM)
+      app.inputKey(.ansiF)
+      app.inputKey(.ansiS)
+      XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.inputText("\n", key: .return, modifiers: .option)
+      XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.controller.candidateSelectionChanged(NSAttributedString(string: "韓: 나라 이름 한"))
+      XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.controller.candidateSelected(NSAttributedString(string: "韓: 나라 이름 한"))
+      XCTAssertEqual("韓", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
     }
+  }
 
-    func testNotifyUpdate() {
-        let data = """
-        {
-            "version": "1.10.0",
-            "description": "Mojave 대응을 포함한 대형 업데이트",
-            "url": "https://github.com/gureum/gureum/releases/tag/1.10.0"
-        }
-        """.data(using: .utf8)
-        let update = try! JSONDecoder().decode(UpdateManager.UpdateInfo.self, from: data!)
+  func testHanjaWord() {
+    for app in apps {
+      if app == terminal {
+        continue  // 터미널은 한자 모드 진입이 불가능
+      }
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han3Final.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      // hanja search mode
+      app.inputText("\n", key: .return, modifiers: .option)
+      app.inputKey(.ansiI)
+      app.inputKey(.ansiB)
+      app.inputKey(.ansiW)
+      XCTAssertEqual("물", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.inputText(" ", key: .space)
+      XCTAssertEqual("물 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물 ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.inputKey(.ansiN)
+      app.inputKey(.ansiB)
+      XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.controller.candidateSelectionChanged(NSAttributedString(string: "水: 물 수, 고를 수"))
+      XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.controller.candidateSelected(NSAttributedString(string: "水: 물 수, 고를 수"))
+      XCTAssertEqual("水", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
 
-        let versionInfo = UpdateManager.VersionInfo(update: update, experimental: true)
-        UpdateManager.notifyUpdate(info: versionInfo)
-        XCTAssertEqual("최신 버전: 1.10.0 현재 버전: \(Bundle.main.version ?? "-")\nMojave 대응을 포함한 대형 업데이트", lastNotification.informativeText)
-        XCTAssertEqual(["url": "https://github.com/gureum/gureum/releases/tag/1.10.0"], lastNotification.userInfo as! [String: String])
+      // 연달아 다음 한자 입력에 들어간다
+      app.inputText(" ", key: .space)
+      XCTAssertEqual("水 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.inputKey(.ansiI)
+      XCTAssertEqual("水 ㅁ", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("ㅁ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.inputKey(.ansiB)
+      app.inputKey(.ansiW)
+      XCTAssertEqual("水 물", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.inputText(" ", key: .space)
+      XCTAssertEqual("水 물 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물 ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.inputKey(.ansiN)
+      app.inputKey(.ansiB)
+      XCTAssertEqual("水 물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.controller.candidateSelectionChanged(NSAttributedString(string: "水: 물 수, 고를 수"))
+      XCTAssertEqual("水 물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.controller.candidateSelected(NSAttributedString(string: "水: 물 수, 고를 수"))
+      XCTAssertEqual("水 水", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
     }
+  }
 
-    func testLayoutChange() {
-        Configuration.shared.inputModeExchangeKey = Configuration.Shortcut(.space, .shift)
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue("org.youknowone.inputmethod.Gureum.qwerty", forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputFlags(.capsLock)
-
-            app.inputText(" ", key: .space, modifiers: .shift)
-            app.inputText(" ", key: .space, modifiers: .shift)
-            XCTAssertEqual("", app.client.string, "buffer: \(app.client.string), app: \(app)")
-        }
+  func testHanjaBlank() {
+    for app in apps {
+      if app == terminal {
+        continue  // 터미널은 한자 모드 진입이 불가능
+      }
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      // hanja search mode
+      app.inputText("\n", key: .return, modifiers: .option)
+      app.inputText(" ", key: .space)
+      app.inputKey(.ansiA)
+      app.inputKey(.ansiN)
+      app.inputKey(.ansiF)
+      XCTAssertEqual(" 물", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.inputText(" ", key: .space)
+      XCTAssertEqual(" 물 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물 ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.inputKey(.ansiT)
+      app.inputKey(.ansiN)
+      app.inputText(" ", key: .space)
+      XCTAssertEqual(" 물 수 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물 수 ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.controller.candidateSelectionChanged(NSAttributedString(string: "水: 물 수, 고를 수"))
+      XCTAssertEqual(" 물 수 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물 수 ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.controller.candidateSelected(NSAttributedString(string: "水: 물 수, 고를 수"))
+      XCTAssertEqual(" 水", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
     }
+  }
 
-    func testLayoutChangeCommit() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue("org.youknowone.inputmethod.Gureum.han2", forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputKey(.ansiG)
-            XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            app.inputFlags(.capsLock)
-            XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string), app: \(app)")
-        }
+  func testHanjaSelection() {
+    for app in apps {
+      if app == terminal {
+        continue  // 터미널은 한자 모드 진입이 불가능
+      }
+      app.client.string = "물 수"
+      app.controller.setValue(
+        GureumInputSource.han3Final.rawValue,
+        forTag: kTextServiceInputModePropertyTag, client: app.client)
+      app.client.setSelectedRange(NSMakeRange(0, 3))
+      XCTAssertEqual("물 수", app.client.selectedString(), "")
+      app.inputText("\n", key: .return, modifiers: .option)
+      XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.controller.candidateSelectionChanged(NSAttributedString(string: "水: 물 수, 고를 수"))
+      XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.controller.candidateSelected(NSAttributedString(string: "水: 물 수, 고를 수"))
+      XCTAssertEqual("水", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testCapsLockLanguageSwitchCapableInfoPlist() {
-        let infoDictionary = Bundle.main.infoDictionary ?? [:]
-        XCTAssertEqual(infoDictionary["TICapsLockLanguageSwitchCapable"] as? Bool, true)
-
-        let componentInputModeDict = infoDictionary["ComponentInputModeDict"] as? [String: Any]
-        let inputModes = componentInputModeDict?["tsInputModeListKey"] as? [String: [String: Any]]
-        let missingCapableInputModes = inputModes?
-            .filter { $0.key.hasPrefix("org.youknowone.inputmethod.Gureum.") }
-            .compactMap { inputMode, properties in
-                (properties["TICapsLockLanguageSwitchCapable"] as? Bool) == true ? nil : inputMode
-            }
-            .sorted()
-
-        XCTAssertEqual(missingCapableInputModes, [])
+  func testHanjaEscapeSyllable() {
+    for app in apps {
+      if app == terminal {
+        continue  // 터미널은 한자 모드 진입이 불가능
+      }
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputKey(.ansiG)
+      app.inputKey(.ansiK)
+      app.inputKey(.ansiS)
+      XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.inputText("\n", key: .return, modifiers: .option)
+      XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.controller.candidateSelectionChanged(NSAttributedString(string: "韓: 나라 이름 한"))
+      XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      // Escape from Hanja mode
+      app.inputText("\n", key: .return, modifiers: .option)
+      XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testSearchEmoticonTable() {
-        let bundle = Bundle(for: HGKeyboard.self)
-        let path: String? = bundle.path(forResource: "emoji", ofType: "txt", inDirectory: "hanja")
-        let table = HGHanjaTable(contentOfFile: path!)!
-        let list: HGHanjaList = table.hanjas(byPrefixSearching: "hushed") ?? HGHanjaList() // 현재 5글자 이상만 가능
-        XCTAssert(list.count > 0)
+  func testHanjaEscapeWord() {
+    for app in apps {
+      if app == terminal {
+        continue  // 터미널은 한자 모드 진입이 불가능
+      }
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      // hanja search mode
+      app.inputText("\n", key: .return, modifiers: .option)
+      app.inputKey(.ansiA)
+      app.inputKey(.ansiN)
+      app.inputKey(.ansiF)
+      XCTAssertEqual("물", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.inputText(" ", key: .space)
+      XCTAssertEqual("물 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물 ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.inputKey(.ansiT)
+      app.inputKey(.ansiN)
+      XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      app.controller.candidateSelectionChanged(NSAttributedString(string: "水: 물 수, 고를 수"))
+      XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+      // Escape from Hanja mode
+      app.inputText("\n", key: .return, modifiers: .option)
+      XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
     }
+  }
 
-    func testCommandkeyAndControlkey() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.qwerty.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputKey(.ansiA, modifiers: .command)
-            app.inputKey(.ansiA, modifiers: .control)
-            XCTAssertEqual("", app.client.string, "")
-            XCTAssertEqual("", app.client.markedString(), "")
-        }
+  func testHanjaEscapeSelection() {
+    for app in apps {
+      if app == terminal {
+        continue  // 터미널은 한자 모드 진입이 불가능
+      }
+      app.client.string = "물 수"
+      app.controller.setValue(
+        GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.client.setSelectedRange(NSMakeRange(0, 3))
+      XCTAssertEqual("물 수", app.client.selectedString(), "")
+      app.inputText("\n", key: .return, modifiers: .option)
+      XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.controller.candidateSelectionChanged(NSAttributedString(string: "水: 물 수, 고를 수"))
+      XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      // Escape from Hanja mode
+      app.inputText("\n", key: .return, modifiers: .option)
+      XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testCapslockRoman() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.qwerty.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputKey(.ansiM)
-            app.inputKey(.ansiR)
-            app.inputKey(.ansi2)
-            XCTAssertEqual("mr2", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.qwerty.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputKey(.ansiM, modifiers: .capsLock)
-            app.inputKey(.ansiR, modifiers: .capsLock)
-            app.inputKey(.ansi2, modifiers: .capsLock)
-            XCTAssertEqual("MR2", app.client.string, "buffer: \(app.client.string), app: \(app)")
-        }
+  func testBackQuoteHan2() {
+    Configuration.shared.hangulWonCurrencySymbolForBackQuote = true
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+
+      app.inputKey(.ansiGrave)
+      XCTAssertEqual("₩", app.client.string, "buffer: \(app.client.string) app: \(app)")
+
+      app.inputKey(.ansiGrave, modifiers: .shift)
+      XCTAssertEqual("₩~", app.client.string, "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testHanjaSyllable() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han3Final.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputKey(.ansiM)
-            app.inputKey(.ansiF)
-            app.inputKey(.ansiS)
-            XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.inputText("\n", key: .return, modifiers: .option)
-            XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.controller.candidateSelectionChanged(NSAttributedString(string: "韓: 나라 이름 한"))
-            XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.controller.candidateSelected(NSAttributedString(string: "韓: 나라 이름 한"))
-            XCTAssertEqual("韓", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-        }
+  func testBackQuoteOnComposing() {
+    Configuration.shared.hangulWonCurrencySymbolForBackQuote = true
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+
+      app.inputKey(.ansiR)
+      app.inputKey(.ansiK)
+      XCTAssertEqual("가", app.client.string, "buffer: \(app.client.string) app: \(app)")
+
+      app.inputKey(.ansiGrave)
+      XCTAssertEqual("가₩", app.client.string, "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testHanjaWord() {
-        for app in apps {
-            if app == terminal {
-                continue // 터미널은 한자 모드 진입이 불가능
-            }
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han3Final.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-            // hanja search mode
-            app.inputText("\n", key: .return, modifiers: .option)
-            app.inputKey(.ansiI)
-            app.inputKey(.ansiB)
-            app.inputKey(.ansiW)
-            XCTAssertEqual("물", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.inputText(" ", key: .space)
-            XCTAssertEqual("물 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물 ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.inputKey(.ansiN)
-            app.inputKey(.ansiB)
-            XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.controller.candidateSelectionChanged(NSAttributedString(string: "水: 물 수, 고를 수"))
-            XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.controller.candidateSelected(NSAttributedString(string: "水: 물 수, 고를 수"))
-            XCTAssertEqual("水", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
+  func testBackQuoteQwerty() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.qwerty.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
 
-            // 연달아 다음 한자 입력에 들어간다
-            app.inputText(" ", key: .space)
-            XCTAssertEqual("水 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.inputKey(.ansiI)
-            XCTAssertEqual("水 ㅁ", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("ㅁ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.inputKey(.ansiB)
-            app.inputKey(.ansiW)
-            XCTAssertEqual("水 물", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.inputText(" ", key: .space)
-            XCTAssertEqual("水 물 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물 ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.inputKey(.ansiN)
-            app.inputKey(.ansiB)
-            XCTAssertEqual("水 물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.controller.candidateSelectionChanged(NSAttributedString(string: "水: 물 수, 고를 수"))
-            XCTAssertEqual("水 물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.controller.candidateSelected(NSAttributedString(string: "水: 물 수, 고를 수"))
-            XCTAssertEqual("水 水", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-        }
+      app.inputKey(.ansiGrave)
+      XCTAssertEqual("`", app.client.string, "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testHanjaBlank() {
-        for app in apps {
-            if app == terminal {
-                continue // 터미널은 한자 모드 진입이 불가능
-            }
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-            // hanja search mode
-            app.inputText("\n", key: .return, modifiers: .option)
-            app.inputText(" ", key: .space)
-            app.inputKey(.ansiA)
-            app.inputKey(.ansiN)
-            app.inputKey(.ansiF)
-            XCTAssertEqual(" 물", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.inputText(" ", key: .space)
-            XCTAssertEqual(" 물 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물 ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.inputKey(.ansiT)
-            app.inputKey(.ansiN)
-            app.inputText(" ", key: .space)
-            XCTAssertEqual(" 물 수 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물 수 ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.controller.candidateSelectionChanged(NSAttributedString(string: "水: 물 수, 고를 수"))
-            XCTAssertEqual(" 물 수 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물 수 ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.controller.candidateSelected(NSAttributedString(string: "水: 물 수, 고를 수"))
-            XCTAssertEqual(" 水", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-        }
+  func testBackQuoteHan3Final() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han3Final.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+
+      app.inputText("`", key: .ansiGrave)
+      XCTAssertEqual("*", app.client.string, "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testHanjaSelection() {
-        for app in apps {
-            if app == terminal {
-                continue // 터미널은 한자 모드 진입이 불가능
-            }
-            app.client.string = "물 수"
-            app.controller.setValue(GureumInputSource.han3Final.rawValue,
-                                    forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.client.setSelectedRange(NSMakeRange(0, 3))
-            XCTAssertEqual("물 수", app.client.selectedString(), "")
-            app.inputText("\n", key: .return, modifiers: .option)
-            XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.controller.candidateSelectionChanged(NSAttributedString(string: "水: 물 수, 고를 수"))
-            XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.controller.candidateSelected(NSAttributedString(string: "水: 물 수, 고를 수"))
-            XCTAssertEqual("水", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-        }
+  func testDvorak() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        "org.youknowone.inputmethod.Gureum.dvorak", forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+
+      app.inputKey(.ansiJ)
+      app.inputKey(.ansiD)
+      app.inputKey(.ansiP)
+      app.inputKey(.ansiP)
+      app.inputKey(.ansiS)
+      XCTAssertEqual("hello", app.client.string, "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testHanjaEscapeSyllable() {
-        for app in apps {
-            if app == terminal {
-                continue // 터미널은 한자 모드 진입이 불가능
-            }
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputKey(.ansiG)
-            app.inputKey(.ansiK)
-            app.inputKey(.ansiS)
-            XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.inputText("\n", key: .return, modifiers: .option)
-            XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.controller.candidateSelectionChanged(NSAttributedString(string: "韓: 나라 이름 한"))
-            XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            // Escape from Hanja mode
-            app.inputText("\n", key: .return, modifiers: .option)
-            XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-        }
+  func test3Number() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        "org.youknowone.inputmethod.Gureum.han3final", forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputKey(.ansiK, modifiers: .shift)
+      XCTAssertEqual("2", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testHanjaEscapeWord() {
-        for app in apps {
-            if app == terminal {
-                continue // 터미널은 한자 모드 진입이 불가능
-            }
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-            // hanja search mode
-            app.inputText("\n", key: .return, modifiers: .option)
-            app.inputKey(.ansiA)
-            app.inputKey(.ansiN)
-            app.inputKey(.ansiF)
-            XCTAssertEqual("물", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.inputText(" ", key: .space)
-            XCTAssertEqual("물 ", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물 ", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.inputKey(.ansiT)
-            app.inputKey(.ansiN)
-            XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            app.controller.candidateSelectionChanged(NSAttributedString(string: "水: 물 수, 고를 수"))
-            XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-            // Escape from Hanja mode
-            app.inputText("\n", key: .return, modifiers: .option)
-            XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string), app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string), app: \(app)")
-        }
+  func testBlock() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        "org.youknowone.inputmethod.Gureum.qwerty", forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputKey(.ansiM)
+      app.inputKey(.ansiF)
+      app.inputKey(.ansiS)
+      app.inputKey(.ansiK)
+      app.inputKey(.ansiG)
+      app.inputKey(.ansiW)
+      XCTAssertEqual("mfskgw", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputText(" ", key: .space)
+
+      app.inputText("", key: .leftArrow)
+      app.inputText("", key: .leftArrow)
+      app.inputText("", key: .leftArrow)
+      app.inputText("", key: .leftArrow)
+      app.inputText("", key: .leftArrow)
+      app.inputText("", key: .leftArrow)
     }
+  }
 
-    func testHanjaEscapeSelection() {
-        for app in apps {
-            if app == terminal {
-                continue // 터미널은 한자 모드 진입이 불가능
-            }
-            app.client.string = "물 수"
-            app.controller.setValue(GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.client.setSelectedRange(NSMakeRange(0, 3))
-            XCTAssertEqual("물 수", app.client.selectedString(), "")
-            app.inputText("\n", key: .return, modifiers: .option)
-            XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.controller.candidateSelectionChanged(NSAttributedString(string: "水: 물 수, 고를 수"))
-            XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("물 수", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            // Escape from Hanja mode
-            app.inputText("\n", key: .return, modifiers: .option)
-            XCTAssertEqual("물 수", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-        }
+  func test3final() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        "org.youknowone.inputmethod.Gureum.han3final", forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputKey(.ansiM)
+      app.inputKey(.ansiF)
+      app.inputKey(.ansiS)
+      XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiK)
+      XCTAssertEqual("한ㄱ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("ㄱ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiG)
+      XCTAssertEqual("한그", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("그", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiW)
+      XCTAssertEqual("한글", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("글", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputText(" ", key: .space)
+      XCTAssertEqual("한글 ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiM)
+      XCTAssertEqual("한글 ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("ㅎ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiF)
+      app.inputKey(.ansiS)
+      XCTAssertEqual("한글 한", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiK)
+      XCTAssertEqual("한글 한ㄱ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("ㄱ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiG)
+      app.inputKey(.ansiW)
+      XCTAssertEqual("한글 한글", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("글", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputText("\n", key: .return)
+      if app != terminal {
+        XCTAssertEqual("한글 한글\n", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      }
     }
+  }
 
-    func testBackQuoteHan2() {
-        Configuration.shared.hangulWonCurrencySymbolForBackQuote = true
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
+  func testColemak() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.colemak.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
 
-            app.inputKey(.ansiGrave)
-            XCTAssertEqual("₩", app.client.string, "buffer: \(app.client.string) app: \(app)")
-
-            app.inputKey(.ansiGrave, modifiers: .shift)
-            XCTAssertEqual("₩~", app.client.string, "buffer: \(app.client.string) app: \(app)")
-        }
+      app.inputKey(.ansiH)
+      app.inputKey(.ansiK)
+      app.inputKey(.ansiU)
+      app.inputKey(.ansiU)
+      app.inputKey(.ansiSemicolon)
+      app.inputKey(.ansiSlash, modifiers: .shift)
+      XCTAssertEqual("hello?", app.client.string, "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testBackQuoteOnComposing() {
-        Configuration.shared.hangulWonCurrencySymbolForBackQuote = true
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
+  func test2() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
 
-            app.inputKey(.ansiR)
-            app.inputKey(.ansiK)
-            XCTAssertEqual("가", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiG)
+      app.inputKey(.ansiK)
+      app.inputKey(.ansiS)
+      XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiR)
+      XCTAssertEqual("한ㄱ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("ㄱ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiM)
+      app.inputKey(.ansiF)
+      XCTAssertEqual("한글", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("글", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputText(" ", key: .space)
+      XCTAssertEqual("한글 ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
 
-            app.inputKey(.ansiGrave)
-            XCTAssertEqual("가₩", app.client.string, "buffer: \(app.client.string) app: \(app)")
-        }
+      app.inputKey(.ansiG)
+      XCTAssertEqual("한글 ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("ㅎ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiK)
+      app.inputKey(.ansiS)
+      XCTAssertEqual("한글 한", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiR)
+      XCTAssertEqual("한글 한ㄱ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("ㄱ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiM)
+      app.inputKey(.ansiF)
+      XCTAssertEqual("한글 한글", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("글", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputText("\n", key: .return)
+      if app != terminal {
+        XCTAssertEqual("한글 한글\n", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      }
     }
+  }
 
-    func testBackQuoteQwerty() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.qwerty.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
+  func testCapslockHangul() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han3Final.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
 
-            app.inputKey(.ansiGrave)
-            XCTAssertEqual("`", app.client.string, "buffer: \(app.client.string) app: \(app)")
-        }
+      app.inputKey(.ansiM)
+      app.inputKey(.ansiR)
+      app.inputKey(.ansi2)
+      XCTAssertEqual("했", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("했", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+
+      app.inputText(" ", key: .space)
+
+      app.client.string = ""
+      app.inputKey(.ansiM, modifiers: .capsLock)
+      app.inputKey(.ansiR, modifiers: .capsLock)
+      app.inputKey(.ansi2, modifiers: .capsLock)
+      XCTAssertEqual("했", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("했", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testBackQuoteHan3Final() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han3Final.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
+  func testRomanEmoticon() {
+    for app in apps {
+      if app == terminal {
+        continue
+      }
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.qwerty.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
 
-            app.inputText("`", key: .ansiGrave)
-            XCTAssertEqual("*", app.client.string, "buffer: \(app.client.string) app: \(app)")
-        }
+      let composer = app.controller.receiver.composer
+      let emoticonComposer = composer.searchComposer
+      emoticonComposer.delegate = composer.delegate
+      composer.delegate = emoticonComposer
+
+      app.inputKey(.ansiS)
+      app.inputKey(.ansiL)
+      app.inputKey(.ansiE)
+      app.inputKey(.ansiE)
+      app.inputKey(.ansiP)
+      app.inputKey(.ansiY)
+      XCTAssertEqual("sleepy", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual(
+        "sleepy", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputText(" ", key: .space)
+      XCTAssertEqual("sleepy ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual(
+        "sleepy ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiF)
+      app.inputKey(.ansiA)
+      app.inputKey(.ansiC)
+      app.inputKey(.ansiE)
+      XCTAssertEqual("sleepy face", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual(
+        "sleepy face", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.controller.candidateSelectionChanged(NSAttributedString(string: "😪: sleepy face"))
+      XCTAssertEqual("sleepy face", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual(
+        "sleepy face", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.controller.candidateSelected(NSAttributedString(string: "😪: sleepy face"))
+      XCTAssertEqual("😪", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+
+      app.client.string = ""
+      app.inputKey(.ansiH)
+      app.inputKey(.ansiU)
+      app.inputKey(.ansiS)
+      app.inputKey(.ansiH)
+      app.inputKey(.ansiE)
+      app.inputKey(.ansiD)
+      XCTAssertEqual("hushed", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual(
+        "hushed", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputText(" ", key: .space)
+      XCTAssertEqual("hushed ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual(
+        "hushed ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiF)
+      app.inputKey(.ansiA)
+      app.inputKey(.ansiC)
+      app.inputKey(.ansiE)
+      XCTAssertEqual("hushed face", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual(
+        "hushed face", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.controller.candidateSelectionChanged(NSAttributedString(string: "😯: hushed face"))
+      XCTAssertEqual("hushed face", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual(
+        "hushed face", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.controller.candidateSelected(NSAttributedString(string: "😯:, hushed face"))
+      XCTAssertEqual("😯", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testDvorak() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue("org.youknowone.inputmethod.Gureum.dvorak", forTag: kTextServiceInputModePropertyTag, client: app.client)
+  func testHan3UnicodeArea() {
+    for app in apps {
+      // 두벌식 ㅑㄴ
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputKey(.ansiI)
+      app.inputKey(.ansiS)
+      XCTAssertEqual("ㅑㄴ", app.client.string, "buffer: \(app.client.string) app: \(app)")
 
-            app.inputKey(.ansiJ)
-            app.inputKey(.ansiD)
-            app.inputKey(.ansiP)
-            app.inputKey(.ansiP)
-            app.inputKey(.ansiS)
-            XCTAssertEqual("hello", app.client.string, "buffer: \(app.client.string) app: \(app)")
-        }
+      let han2 = app.client.string
+      app.inputText(" ", key: .space)
+
+      // 세벌식 ㅑㄴ
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han3FinalNoShift.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputKey(.ansi6)
+      app.inputKey(.ansiS)
+      XCTAssertEqual(han2, app.client.string, "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func test3Number() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue("org.youknowone.inputmethod.Gureum.han3final", forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputKey(.ansiK, modifiers: .shift)
-            XCTAssertEqual("2", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-        }
+  func testViModeEscape() {
+    XCTAssertFalse(Configuration.shared.romanModeByEscapeKey)
+    Configuration.shared.romanModeByEscapeKey = true
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han3FinalNoShift.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+
+      app.inputKey(.ansiM)
+      XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+
+      let processed = app.inputKey(.escape)
+      XCTAssertFalse(processed)
+      XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertTrue(app.controller.receiver.composer.inputMode.hasSuffix("qwerty"))
     }
+  }
 
-    func testBlock() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue("org.youknowone.inputmethod.Gureum.qwerty", forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputKey(.ansiM)
-            app.inputKey(.ansiF)
-            app.inputKey(.ansiS)
-            app.inputKey(.ansiK)
-            app.inputKey(.ansiG)
-            app.inputKey(.ansiW)
-            XCTAssertEqual("mfskgw", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputText(" ", key: .space)
+  func testViModeCtrlAndLeftBracket() {
+    XCTAssertFalse(Configuration.shared.romanModeByEscapeKey)
+    Configuration.shared.romanModeByEscapeKey = true
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han3FinalNoShift.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
 
-            app.inputText("", key: .leftArrow)
-            app.inputText("", key: .leftArrow)
-            app.inputText("", key: .leftArrow)
-            app.inputText("", key: .leftArrow)
-            app.inputText("", key: .leftArrow)
-            app.inputText("", key: .leftArrow)
-        }
+      app.inputKey(.ansiM)
+      XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+
+      let processed = app.inputKey(.ansiLeftBracket, modifiers: [.control])
+      XCTAssertFalse(processed)
+      XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertTrue(app.controller.receiver.composer.inputMode.hasSuffix("qwerty"))
+
+      app.inputKey(.ansiLeftBracket, modifiers: [.control, .shift])
+      XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertTrue(app.controller.receiver.composer.inputMode.hasSuffix("qwerty"))
     }
+  }
 
-    func test3final() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue("org.youknowone.inputmethod.Gureum.han3final", forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputKey(.ansiM)
-            app.inputKey(.ansiF)
-            app.inputKey(.ansiS)
-            XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiK)
-            XCTAssertEqual("한ㄱ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("ㄱ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiG)
-            XCTAssertEqual("한그", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("그", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiW)
-            XCTAssertEqual("한글", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("글", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputText(" ", key: .space)
-            XCTAssertEqual("한글 ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiM)
-            XCTAssertEqual("한글 ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("ㅎ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiF)
-            app.inputKey(.ansiS)
-            XCTAssertEqual("한글 한", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiK)
-            XCTAssertEqual("한글 한ㄱ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("ㄱ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiG)
-            app.inputKey(.ansiW)
-            XCTAssertEqual("한글 한글", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("글", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputText("\n", key: .return)
-            if app != terminal {
-                XCTAssertEqual("한글 한글\n", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            }
-        }
+  func testHanClassic() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han3Classic.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+
+      app.inputKey(.ansiM)
+      XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiF)
+      XCTAssertEqual("하", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiF)
+      XCTAssertEqual("ᄒᆞ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      app.inputKey(.ansiS)
+      XCTAssertEqual("ᄒᆞᆫ", app.client.string, "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func testColemak() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.colemak.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-
-            app.inputKey(.ansiH)
-            app.inputKey(.ansiK)
-            app.inputKey(.ansiU)
-            app.inputKey(.ansiU)
-            app.inputKey(.ansiSemicolon)
-            app.inputKey(.ansiSlash, modifiers: .shift)
-            XCTAssertEqual("hello?", app.client.string, "buffer: \(app.client.string) app: \(app)")
-        }
+  func testHanDelete() {
+    for app in apps {
+      app.client.string = ""
+      app.controller.setValue(
+        GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag,
+        client: app.client)
+      app.inputKey(.ansiD)
+      XCTAssertEqual("ㅇ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("ㅇ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.inputText("", key: .delete)
+      XCTAssertEqual("", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
     }
+  }
 
-    func test2() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-
-            app.inputKey(.ansiG)
-            app.inputKey(.ansiK)
-            app.inputKey(.ansiS)
-            XCTAssertEqual("한", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiR)
-            XCTAssertEqual("한ㄱ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("ㄱ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiM)
-            app.inputKey(.ansiF)
-            XCTAssertEqual("한글", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("글", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputText(" ", key: .space)
-            XCTAssertEqual("한글 ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-
-            app.inputKey(.ansiG)
-            XCTAssertEqual("한글 ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("ㅎ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiK)
-            app.inputKey(.ansiS)
-            XCTAssertEqual("한글 한", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("한", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiR)
-            XCTAssertEqual("한글 한ㄱ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("ㄱ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiM)
-            app.inputKey(.ansiF)
-            XCTAssertEqual("한글 한글", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("글", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputText("\n", key: .return)
-            if app != terminal {
-                XCTAssertEqual("한글 한글\n", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            }
-        }
+  func testSearchPool() {
+    for (pool, key, test) in [
+      (SearchSourceConst.emojiKorean, "사과", "사과"),
+      (SearchSourceConst.hanjaReversed, "물 수", "水"),
+    ] {
+      let workItem = DispatchWorkItem {}
+      let candidates = pool.collect(key, workItem: workItem)
+      let c = candidates[0]
+      XCTAssertTrue(c.candidate.value == test || c.candidate.description.contains(test))
     }
+  }
 
-    func testCapslockHangul() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han3Final.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-
-            app.inputKey(.ansiM)
-            app.inputKey(.ansiR)
-            app.inputKey(.ansi2)
-            XCTAssertEqual("했", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("했", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-
-            app.inputText(" ", key: .space)
-
-            app.client.string = ""
-            app.inputKey(.ansiM, modifiers: .capsLock)
-            app.inputKey(.ansiR, modifiers: .capsLock)
-            app.inputKey(.ansi2, modifiers: .capsLock)
-            XCTAssertEqual("했", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("했", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-        }
+  func testSearchPoolWithoutDuplicate() {
+    for (pool, key, test) in [
+      (SearchSourceConst.koreanSingle, "구", "九")
+    ] {
+      let workItem = DispatchWorkItem {}
+      let candidates = pool.collect(key, workItem: workItem)
+      XCTAssertEqual(1, candidates.filter { $0.candidate.value == test }.count)
     }
+  }
 
-    func testRomanEmoticon() {
-        for app in apps {
-            if app == terminal {
-                continue
-            }
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.qwerty.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-
-            let composer = app.controller.receiver.composer
-            let emoticonComposer = composer.searchComposer
-            emoticonComposer.delegate = composer.delegate
-            composer.delegate = emoticonComposer
-
-            app.inputKey(.ansiS)
-            app.inputKey(.ansiL)
-            app.inputKey(.ansiE)
-            app.inputKey(.ansiE)
-            app.inputKey(.ansiP)
-            app.inputKey(.ansiY)
-            XCTAssertEqual("sleepy", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("sleepy", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputText(" ", key: .space)
-            XCTAssertEqual("sleepy ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("sleepy ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiF)
-            app.inputKey(.ansiA)
-            app.inputKey(.ansiC)
-            app.inputKey(.ansiE)
-            XCTAssertEqual("sleepy face", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("sleepy face", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.controller.candidateSelectionChanged(NSAttributedString(string: "😪: sleepy face"))
-            XCTAssertEqual("sleepy face", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("sleepy face", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.controller.candidateSelected(NSAttributedString(string: "😪: sleepy face"))
-            XCTAssertEqual("😪", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-
-            app.client.string = ""
-            app.inputKey(.ansiH)
-            app.inputKey(.ansiU)
-            app.inputKey(.ansiS)
-            app.inputKey(.ansiH)
-            app.inputKey(.ansiE)
-            app.inputKey(.ansiD)
-            XCTAssertEqual("hushed", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("hushed", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputText(" ", key: .space)
-            XCTAssertEqual("hushed ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("hushed ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiF)
-            app.inputKey(.ansiA)
-            app.inputKey(.ansiC)
-            app.inputKey(.ansiE)
-            XCTAssertEqual("hushed face", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("hushed face", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.controller.candidateSelectionChanged(NSAttributedString(string: "😯: hushed face"))
-            XCTAssertEqual("hushed face", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("hushed face", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.controller.candidateSelected(NSAttributedString(string: "😯:, hushed face"))
-            XCTAssertEqual("😯", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-        }
-    }
-
-    func testHan3UnicodeArea() {
-        for app in apps {
-            // 두벌식 ㅑㄴ
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputKey(.ansiI)
-            app.inputKey(.ansiS)
-            XCTAssertEqual("ㅑㄴ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-
-            let han2 = app.client.string
-            app.inputText(" ", key: .space)
-
-            // 세벌식 ㅑㄴ
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han3FinalNoShift.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputKey(.ansi6)
-            app.inputKey(.ansiS)
-            XCTAssertEqual(han2, app.client.string, "buffer: \(app.client.string) app: \(app)")
-        }
-    }
-
-    func testViModeEscape() {
-        XCTAssertFalse(Configuration.shared.romanModeByEscapeKey)
-        Configuration.shared.romanModeByEscapeKey = true
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han3FinalNoShift.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-
-            app.inputKey(.ansiM)
-            XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-
-            let processed = app.inputKey(.escape)
-            XCTAssertFalse(processed)
-            XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertTrue(app.controller.receiver.composer.inputMode.hasSuffix("qwerty"))
-        }
-    }
-
-    func testViModeCtrlAndLeftBracket() {
-        XCTAssertFalse(Configuration.shared.romanModeByEscapeKey)
-        Configuration.shared.romanModeByEscapeKey = true
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han3FinalNoShift.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-
-            app.inputKey(.ansiM)
-            XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-
-            let processed = app.inputKey(.ansiLeftBracket, modifiers: [.control])
-            XCTAssertFalse(processed)
-            XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertTrue(app.controller.receiver.composer.inputMode.hasSuffix("qwerty"))
-
-            app.inputKey(.ansiLeftBracket, modifiers: [.control, .shift])
-            XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertTrue(app.controller.receiver.composer.inputMode.hasSuffix("qwerty"))
-        }
-    }
-
-    func testHanClassic() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han3Classic.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-
-            app.inputKey(.ansiM)
-            XCTAssertEqual("ㅎ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiF)
-            XCTAssertEqual("하", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiF)
-            XCTAssertEqual("ᄒᆞ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            app.inputKey(.ansiS)
-            XCTAssertEqual("ᄒᆞᆫ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-        }
-    }
-
-    func testHanDelete() {
-        for app in apps {
-            app.client.string = ""
-            app.controller.setValue(GureumInputSource.han2.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-            app.inputKey(.ansiD)
-            XCTAssertEqual("ㅇ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("ㅇ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-            app.inputText("", key: .delete)
-            XCTAssertEqual("", app.client.string, "buffer: \(app.client.string) app: \(app)")
-            XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-        }
-    }
-
-    func testSearchPool() {
-        for (pool, key, test) in [
-            (SearchSourceConst.emojiKorean, "사과", "사과"),
-            (SearchSourceConst.hanjaReversed, "물 수", "水"),
-        ] {
-            let workItem = DispatchWorkItem {}
-            let candidates = pool.collect(key, workItem: workItem)
-            let c = candidates[0]
-            XCTAssertTrue(c.candidate.value == test || c.candidate.description.contains(test))
-        }
-    }
-
-    func testSearchPoolWithoutDuplicate() {
-        for (pool, key, test) in [
-            (SearchSourceConst.koreanSingle, "구", "九"),
-        ] {
-            let workItem = DispatchWorkItem {}
-            let candidates = pool.collect(key, workItem: workItem)
-            XCTAssertEqual(1, candidates.filter { $0.candidate.value == test }.count)
-        }
-    }
-
-    //    func testSelection() {
-    //        for app in apps {
-    //            app.client.string = "한"
-    //            app.controller.setValue(GureumInputSourceIdentifier.han2.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-    //            _ = app.inputKey(kVK_ANSI_D)
-    //            XCTAssertEqual("한ㅇ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-    //            XCTAssertEqual("ㅇ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-    //            app.client.setSelectedRange(NSRange(location: 0, length: 0))
-    //            _ = app.inputKey(kVK_ANSI_R)
-    //            XCTAssertEqual("ㄱ한ㅇ", app.client.string, "buffer: \(app.client.string) app: \(app)")
-    //            XCTAssertEqual("ㄱ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-    //        }
-    //    }
+  //    func testSelection() {
+  //        for app in apps {
+  //            app.client.string = "한"
+  //            app.controller.setValue(GureumInputSourceIdentifier.han2.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
+  //            _ = app.inputKey(kVK_ANSI_D)
+  //            XCTAssertEqual("한ㅇ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+  //            XCTAssertEqual("ㅇ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+  //            app.client.setSelectedRange(NSRange(location: 0, length: 0))
+  //            _ = app.inputKey(kVK_ANSI_R)
+  //            XCTAssertEqual("ㄱ한ㅇ", app.client.string, "buffer: \(app.client.string) app: \(app)")
+  //            XCTAssertEqual("ㄱ", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+  //        }
+  //    }
 }
 
 class Han3FinalNoShiftTests: XCTestCase {
-    let app = ModerateApp()
+  let app = ModerateApp()
 
-    override class func setUp() {
-        Configuration.shared = Configuration(suiteName: "org.youknowone.Gureum.test")!
-        super.setUp()
-    }
+  override class func setUp() {
+    Configuration.shared = Configuration(suiteName: "org.youknowone.Gureum.test")!
+    super.setUp()
+  }
 
-    override class func tearDown() {
-        super.tearDown()
-    }
+  override class func tearDown() {
+    super.tearDown()
+  }
 
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+  override func setUp() {
+    super.setUp()
+    // Put setup code here. This method is called before the invocation of each test method in the class.
 
-        Configuration.shared.removePersistentDomain(forName: GureumTests.domainName)
+    Configuration.shared.removePersistentDomain(forName: GureumTests.domainName)
 
-        app.client.string = ""
-        app.controller.setValue(GureumInputSource.han3FinalNoShift.rawValue, forTag: kTextServiceInputModePropertyTag, client: app.client)
-    }
+    app.client.string = ""
+    app.controller.setValue(
+      GureumInputSource.han3FinalNoShift.rawValue, forTag: kTextServiceInputModePropertyTag,
+      client: app.client)
+  }
 
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        app.inputKey(.space)
-        app.client.string = ""
-        super.tearDown()
-    }
+  override func tearDown() {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    app.inputKey(.space)
+    app.client.string = ""
+    super.tearDown()
+  }
 
-    func testSymbol() {
-        app.inputKey(.ansiQuote, modifiers: .shift)
-        XCTAssertEqual("\"", app.client.string, "buffer: \(app.client.string) app: \(app)")
-        app.client.string = ""
-    }
+  func testSymbol() {
+    app.inputKey(.ansiQuote, modifiers: .shift)
+    XCTAssertEqual("\"", app.client.string, "buffer: \(app.client.string) app: \(app)")
+    app.client.string = ""
+  }
 
-    func testModeKeyAsSymbol() {
-        app.inputKey(.ansiLeftBracket)
-        XCTAssertEqual("[", app.client.string, "buffer: \(app.client.string) app: \(app)")
-        XCTAssertEqual("[", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-        app.inputKey(.ansiLeftBracket)
-        XCTAssertEqual("[[", app.client.string, "buffer: \(app.client.string) app: \(app)")
-        XCTAssertEqual("[", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
-    }
+  func testModeKeyAsSymbol() {
+    app.inputKey(.ansiLeftBracket)
+    XCTAssertEqual("[", app.client.string, "buffer: \(app.client.string) app: \(app)")
+    XCTAssertEqual("[", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+    app.inputKey(.ansiLeftBracket)
+    XCTAssertEqual("[[", app.client.string, "buffer: \(app.client.string) app: \(app)")
+    XCTAssertEqual("[", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+  }
 
-    func testBufferedJung() {
-        app.test(input: "fd", expecteds: ["ㅏ", "ㅏㅣ"], markeds: ["ㅏ", "ㅏㅣ"])
-        app.test(input: "fds", expecteds: ["ㅏ", "ㅏㅣ", "ㅏㅣㄴ"], markeds: ["ㅏ", "ㅏㅣ", "ㅣㄴ"])
-        app.test(input: "fde", expecteds: ["ㅏ", "ㅏㅣ", "ㅏㅣㅕ"], markeds: ["ㅏ", "ㅏㅣ", "ㅣㅕ"])
-        app.test(input: "fdk", expecteds: ["ㅏ", "ㅏㅣ", "ㅏ기"], markeds: ["ㅏ", "ㅏㅣ", "기"])
-        app.test(input: "fdk", expecteds: ["ㅏ", "ㅏㅣ", "ㅏ기"], markeds: ["ㅏ", "ㅏㅣ", "기"])
-        app.test(input: "fdsk", expecteds: ["ㅏ", "ㅏㅣ", "ㅏㅣㄴ", "ㅏ긴"], markeds: ["ㅏ", "ㅏㅣ", "ㅣㄴ", "긴"])
-        app.test(input: "fsdk", expecteds: ["ㅏ", "ㅏㄴ", "ㅏㄴㅣ", "ㅏㄴ기"], markeds: ["ㅏ", "ㅏㄴ", "ㅣ", "기"], removeds: ["ㅏㄴㅣ", "ㅏㄴ"])
-    }
+  func testBufferedJung() {
+    app.test(input: "fd", expecteds: ["ㅏ", "ㅏㅣ"], markeds: ["ㅏ", "ㅏㅣ"])
+    app.test(input: "fds", expecteds: ["ㅏ", "ㅏㅣ", "ㅏㅣㄴ"], markeds: ["ㅏ", "ㅏㅣ", "ㅣㄴ"])
+    app.test(input: "fde", expecteds: ["ㅏ", "ㅏㅣ", "ㅏㅣㅕ"], markeds: ["ㅏ", "ㅏㅣ", "ㅣㅕ"])
+    app.test(input: "fdk", expecteds: ["ㅏ", "ㅏㅣ", "ㅏ기"], markeds: ["ㅏ", "ㅏㅣ", "기"])
+    app.test(input: "fdk", expecteds: ["ㅏ", "ㅏㅣ", "ㅏ기"], markeds: ["ㅏ", "ㅏㅣ", "기"])
+    app.test(input: "fdsk", expecteds: ["ㅏ", "ㅏㅣ", "ㅏㅣㄴ", "ㅏ긴"], markeds: ["ㅏ", "ㅏㅣ", "ㅣㄴ", "긴"])
+    app.test(
+      input: "fsdk", expecteds: ["ㅏ", "ㅏㄴ", "ㅏㄴㅣ", "ㅏㄴ기"], markeds: ["ㅏ", "ㅏㄴ", "ㅣ", "기"],
+      removeds: ["ㅏㄴㅣ", "ㅏㄴ"])
+  }
 
-    func test까() {
-        app.test(input: "jkf", expecteds: [nil, nil, "까"])
-        app.test(input: "kjf", expecteds: [nil, nil, "까"])
-        app.test(input: "fkj", expecteds: [nil, nil, "까"])
-        app.test(input: "fjk", expecteds: [nil, nil, "까"])
-        app.test(input: "fkji", expecteds: [nil, nil, "까", "까ㅁ"], removeds: ["까", ""])
-        app.test(input: "fjki", expecteds: [nil, nil, "까", "까ㅁ"], removeds: ["까", ""])
-        app.test(input: "jfk", expecteds: [nil, nil, "아ㄱ"], removeds: ["아"])
-        app.test(input: "kfj", expecteds: [nil, nil, "가ㅇ"], removeds: ["가"])
-        app.test(input: "sjkf", expecteds: [nil, nil, nil, "깐"])
-        app.test(input: "skjf", expecteds: [nil, nil, nil, "깐"])
-        app.test(input: "sfkj", expecteds: [nil, nil, nil, "깐"])
-        app.test(input: "sfjk", expecteds: [nil, nil, nil, "깐"])
-        app.test(input: "jksf", expecteds: [nil, nil, nil, "깐"])
-        app.test(input: "kjsf", expecteds: [nil, nil, nil, "깐"])
-        app.test(input: "fskj", expecteds: [nil, nil, nil, "깐"])
-        app.test(input: "fsjk", expecteds: [nil, nil, nil, "깐"])
-    }
+  func test까() {
+    app.test(input: "jkf", expecteds: [nil, nil, "까"])
+    app.test(input: "kjf", expecteds: [nil, nil, "까"])
+    app.test(input: "fkj", expecteds: [nil, nil, "까"])
+    app.test(input: "fjk", expecteds: [nil, nil, "까"])
+    app.test(input: "fkji", expecteds: [nil, nil, "까", "까ㅁ"], removeds: ["까", ""])
+    app.test(input: "fjki", expecteds: [nil, nil, "까", "까ㅁ"], removeds: ["까", ""])
+    app.test(input: "jfk", expecteds: [nil, nil, "아ㄱ"], removeds: ["아"])
+    app.test(input: "kfj", expecteds: [nil, nil, "가ㅇ"], removeds: ["가"])
+    app.test(input: "sjkf", expecteds: [nil, nil, nil, "깐"])
+    app.test(input: "skjf", expecteds: [nil, nil, nil, "깐"])
+    app.test(input: "sfkj", expecteds: [nil, nil, nil, "깐"])
+    app.test(input: "sfjk", expecteds: [nil, nil, nil, "깐"])
+    app.test(input: "jksf", expecteds: [nil, nil, nil, "깐"])
+    app.test(input: "kjsf", expecteds: [nil, nil, nil, "깐"])
+    app.test(input: "fskj", expecteds: [nil, nil, nil, "깐"])
+    app.test(input: "fsjk", expecteds: [nil, nil, nil, "깐"])
+  }
 
-    func testㄺ() {
-        app.test(input: "2[", expecteds: ["ㅆ", "ㄺ"], markeds: ["ㅆ", "ㄺ"])
-        app.test(input: "[2", expecteds: ["[", "ㄺ"], markeds: ["[", "ㄺ"])
-    }
+  func testㄺ() {
+    app.test(input: "2[", expecteds: ["ㅆ", "ㄺ"], markeds: ["ㅆ", "ㄺ"])
+    app.test(input: "[2", expecteds: ["[", "ㄺ"], markeds: ["[", "ㄺ"])
+  }
 
-    func test괜() {
-        app.test(input: "k/r", expecteds: [nil, nil, "괘"])
-        app.test(input: "k/rs", expecteds: [nil, nil, nil, "괜"])
-        app.test(input: "kr/s", expecteds: [nil, nil, nil, "괜"])
-        app.test(input: "krs/", expecteds: [nil, nil, nil, "괜"])
-        app.test(input: "k/sr", expecteds: [nil, nil, nil, "괜"])
-        app.test(input: "ks/r", expecteds: [nil, nil, nil, "괜"])
-        app.test(input: "ksr/", expecteds: [nil, nil, nil, "괜"])
-    }
+  func test괜() {
+    app.test(input: "k/r", expecteds: [nil, nil, "괘"])
+    app.test(input: "k/rs", expecteds: [nil, nil, nil, "괜"])
+    app.test(input: "kr/s", expecteds: [nil, nil, nil, "괜"])
+    app.test(input: "krs/", expecteds: [nil, nil, nil, "괜"])
+    app.test(input: "k/sr", expecteds: [nil, nil, nil, "괜"])
+    app.test(input: "ks/r", expecteds: [nil, nil, nil, "괜"])
+    app.test(input: "ksr/", expecteds: [nil, nil, nil, "괜"])
+  }
 
-    func test뚫() {
-        app.test(input: "iub[r", expecteds: [nil, nil, nil, "뚜[", "뚫"])
-        app.test(input: "iu[br", expecteds: [nil, nil, nil, "뚜[", "뚫"])
-        app.test(input: "iubr[", expecteds: [nil, nil, nil, "뚜ㅐ", "뚫"])
-        app.test(input: "iubr[[", expecteds: [nil, nil, nil, "뚜ㅐ", "뚫", "뚫["], removeds: ["뚫", ""])
-        app.test(input: "bb[r", expecteds: [nil, nil, "ㅜㅜ[", "ㅜㅜㅀ"], markeds: [nil, nil, "ㅜ[", "ㅜㅀ"])
-    }
+  func test뚫() {
+    app.test(input: "iub[r", expecteds: [nil, nil, nil, "뚜[", "뚫"])
+    app.test(input: "iu[br", expecteds: [nil, nil, nil, "뚜[", "뚫"])
+    app.test(input: "iubr[", expecteds: [nil, nil, nil, "뚜ㅐ", "뚫"])
+    app.test(input: "iubr[[", expecteds: [nil, nil, nil, "뚜ㅐ", "뚫", "뚫["], removeds: ["뚫", ""])
+    app.test(input: "bb[r", expecteds: [nil, nil, "ㅜㅜ[", "ㅜㅜㅀ"], markeds: [nil, nil, "ㅜ[", "ㅜㅀ"])
+  }
 
-    func test많() {
-        app.test(input: "if[s[", expecteds: [nil, nil, "맒", "많", "많["], markeds: [nil, nil, nil, nil, "["], removeds: ["많", ""])
-        app.test(input: "ifs[", expecteds: [nil, nil, nil, "많"])
-        app.test(input: "i[fs", expecteds: [nil, nil, nil, "많"])
-        app.test(input: "i[sf", expecteds: [nil, nil, nil, "많"])
-        app.test(input: "isf[", expecteds: [nil, nil, nil, "많"])
-        app.test(input: "is[f", expecteds: [nil, nil, nil, "많"])
-        app.test(input: "isf[f", expecteds: [nil, nil, nil, "많", "많ㅏ"], markeds: [nil, nil, nil, nil, "ㅏ"], removeds: ["많", ""])
-        app.test(input: "is[ff", expecteds: [nil, nil, nil, "많", "많ㅏ"], markeds: [nil, nil, nil, nil, "ㅏ"], removeds: ["많", ""])
-        app.test(input: "isff", expecteds: [nil, nil, "만", "만ㅏ"], markeds: [nil, nil, nil, "ㅏ"], removeds: ["만", ""])
-        app.test(input: "isf[s", expecteds: [nil, nil, nil, "많", "많ㄴ"], markeds: [nil, nil, nil, nil, "ㄴ"], removeds: ["많", ""])
-        app.test(input: "is[fs", expecteds: [nil, nil, nil, "많", "많ㄴ"], markeds: [nil, nil, nil, nil, "ㄴ"], removeds: ["많", ""])
-        app.test(input: "ifss", expecteds: [nil, nil, "만", "만ㄴ"], markeds: [nil, nil, nil, "ㄴ"], removeds: ["만", ""])
-    }
+  func test많() {
+    app.test(
+      input: "if[s[", expecteds: [nil, nil, "맒", "많", "많["], markeds: [nil, nil, nil, nil, "["],
+      removeds: ["많", ""])
+    app.test(input: "ifs[", expecteds: [nil, nil, nil, "많"])
+    app.test(input: "i[fs", expecteds: [nil, nil, nil, "많"])
+    app.test(input: "i[sf", expecteds: [nil, nil, nil, "많"])
+    app.test(input: "isf[", expecteds: [nil, nil, nil, "많"])
+    app.test(input: "is[f", expecteds: [nil, nil, nil, "많"])
+    app.test(
+      input: "isf[f", expecteds: [nil, nil, nil, "많", "많ㅏ"], markeds: [nil, nil, nil, nil, "ㅏ"],
+      removeds: ["많", ""])
+    app.test(
+      input: "is[ff", expecteds: [nil, nil, nil, "많", "많ㅏ"], markeds: [nil, nil, nil, nil, "ㅏ"],
+      removeds: ["많", ""])
+    app.test(
+      input: "isff", expecteds: [nil, nil, "만", "만ㅏ"], markeds: [nil, nil, nil, "ㅏ"],
+      removeds: ["만", ""])
+    app.test(
+      input: "isf[s", expecteds: [nil, nil, nil, "많", "많ㄴ"], markeds: [nil, nil, nil, nil, "ㄴ"],
+      removeds: ["많", ""])
+    app.test(
+      input: "is[fs", expecteds: [nil, nil, nil, "많", "많ㄴ"], markeds: [nil, nil, nil, nil, "ㄴ"],
+      removeds: ["많", ""])
+    app.test(
+      input: "ifss", expecteds: [nil, nil, "만", "만ㄴ"], markeds: [nil, nil, nil, "ㄴ"],
+      removeds: ["만", ""])
+  }
 
-    func test삶() {
-        app.test(input: "nf[f", expecteds: [nil, nil, "삶", "삶"])
-        app.test(input: "n[ff", expecteds: [nil, nil, "삶", "삶"])
-        app.test(input: "nff[", expecteds: [nil, "사", "사ㅏ", "삶"])
-        app.test(input: "f[n", expecteds: [nil, "ㅏㄻ", "삶"])
-        app.test(input: "[fn", expecteds: [nil, "ㅏㄻ", "삶"])
-        app.test(input: "[nf", expecteds: [nil, "ㅅ[", "삶"])
-        app.test(input: "n[[f", expecteds: [nil, "ㅅ[", "ㅅ[[", "ㅅ[ㅏㄻ"])
-        app.test(input: "f[[nf", expecteds: [nil, "ㅏㄻ", "ㅏㄻ[", "ㅏㄻㅅ[", "ㅏㄻ삶"], markeds: [nil, nil, "ㅏㄻ[", "ㅅ[", "삶"])
-    }
+  func test삶() {
+    app.test(input: "nf[f", expecteds: [nil, nil, "삶", "삶"])
+    app.test(input: "n[ff", expecteds: [nil, nil, "삶", "삶"])
+    app.test(input: "nff[", expecteds: [nil, "사", "사ㅏ", "삶"])
+    app.test(input: "f[n", expecteds: [nil, "ㅏㄻ", "삶"])
+    app.test(input: "[fn", expecteds: [nil, "ㅏㄻ", "삶"])
+    app.test(input: "[nf", expecteds: [nil, "ㅅ[", "삶"])
+    app.test(input: "n[[f", expecteds: [nil, "ㅅ[", "ㅅ[[", "ㅅ[ㅏㄻ"])
+    app.test(
+      input: "f[[nf", expecteds: [nil, "ㅏㄻ", "ㅏㄻ[", "ㅏㄻㅅ[", "ㅏㄻ삶"],
+      markeds: [nil, nil, "ㅏㄻ[", "ㅅ[", "삶"])
+  }
 
-    func test얹() {
-        app.test(input: "jt[e", expecteds: [nil, nil, "엀", "얹"])
-        app.test(input: "te[j", expecteds: [nil, "ㅓㅕ", "ㅓㄵ", "얹"])
-    }
+  func test얹() {
+    app.test(input: "jt[e", expecteds: [nil, nil, "엀", "얹"])
+    app.test(input: "te[j", expecteds: [nil, "ㅓㅕ", "ㅓㄵ", "얹"])
+  }
 }
 
 extension VirtualApp {
-    func test(input: String, expecteds: [String?], markeds: [String?]? = nil, removeds: [String?]? = nil) {
-        var results: [(Character, String)] = []
+  func test(
+    input: String, expecteds: [String?], markeds: [String?]? = nil, removeds: [String?]? = nil
+  ) {
+    var results: [(Character, String)] = []
 
-        func strokes() -> String {
-            String(Array(results.map { $0.0 }))
-        }
-
-        XCTAssertEqual(client.string, "", "app.client.string is not cleared")
-        for (i, keyChar) in input.enumerated() {
-            let key = "\(keyChar)"
-            results.append((keyChar, client.string))
-            inputKeys(key)
-            if let expected = expecteds[i] {
-                XCTAssertEqual(expected, client.string, "strokes: \(strokes()) buffer: \(client.string) marked: \(client.markedString()) app: \(self)")
-            }
-            if let markeds = markeds {
-                if let marked = markeds[i] {
-                    XCTAssertEqual(marked, client.markedString(), "buffer: \(client.string) marked: \(client.markedString()) app: \(self)")
-                }
-            }
-        }
-        if var removeds = removeds {
-            while let removed = removeds.first {
-                removeds.remove(at: 0)
-                inputDelete()
-                XCTAssertEqual(removed, client.string, "buffer: \(client.string) marked: \(client.markedString()) app: \(self)")
-            }
-        } else {
-            while let (keyChar, result) = results.popLast() {
-                inputDelete()
-                XCTAssertEqual(result, client.string, "strokes: \(strokes())<BS(\(keyChar))> buffer: \(client.string) marked: \(client.markedString()) app: \(self)")
-            }
-        }
-
-        inputKey(.space)
-        client.string = ""
-
-        inputKeys(input)
-        let result = client.string
-        inputKey(.ansiK)
-        inputDelete()
-        XCTAssertEqual(result, client.string, "input: \(input) 'k' and delete fails buffer: \(client.string) marked: \(client.markedString()) app: \(self)")
-
-        inputKey(.ansiF)
-        inputDelete()
-        XCTAssertEqual(result, client.string, "input: \(input) 'f' and delete fails buffer: \(client.string) marked: \(client.markedString()) app: \(self)")
-
-        inputKey(.ansiS)
-        inputDelete()
-        XCTAssertEqual(result, client.string, "input: \(input) 's' and delete fails buffer: \(client.string) marked: \(client.markedString()) app: \(self)")
-
-        inputKey(.space)
-        client.string = ""
+    func strokes() -> String {
+      String(Array(results.map { $0.0 }))
     }
+
+    XCTAssertEqual(client.string, "", "app.client.string is not cleared")
+    for (i, keyChar) in input.enumerated() {
+      let key = "\(keyChar)"
+      results.append((keyChar, client.string))
+      inputKeys(key)
+      if let expected = expecteds[i] {
+        XCTAssertEqual(
+          expected, client.string,
+          "strokes: \(strokes()) buffer: \(client.string) marked: \(client.markedString()) app: \(self)"
+        )
+      }
+      if let markeds = markeds {
+        if let marked = markeds[i] {
+          XCTAssertEqual(
+            marked, client.markedString(),
+            "buffer: \(client.string) marked: \(client.markedString()) app: \(self)")
+        }
+      }
+    }
+    if var removeds = removeds {
+      while let removed = removeds.first {
+        removeds.remove(at: 0)
+        inputDelete()
+        XCTAssertEqual(
+          removed, client.string,
+          "buffer: \(client.string) marked: \(client.markedString()) app: \(self)")
+      }
+    } else {
+      while let (keyChar, result) = results.popLast() {
+        inputDelete()
+        XCTAssertEqual(
+          result, client.string,
+          "strokes: \(strokes())<BS(\(keyChar))> buffer: \(client.string) marked: \(client.markedString()) app: \(self)"
+        )
+      }
+    }
+
+    inputKey(.space)
+    client.string = ""
+
+    inputKeys(input)
+    let result = client.string
+    inputKey(.ansiK)
+    inputDelete()
+    XCTAssertEqual(
+      result, client.string,
+      "input: \(input) 'k' and delete fails buffer: \(client.string) marked: \(client.markedString()) app: \(self)"
+    )
+
+    inputKey(.ansiF)
+    inputDelete()
+    XCTAssertEqual(
+      result, client.string,
+      "input: \(input) 'f' and delete fails buffer: \(client.string) marked: \(client.markedString()) app: \(self)"
+    )
+
+    inputKey(.ansiS)
+    inputDelete()
+    XCTAssertEqual(
+      result, client.string,
+      "input: \(input) 's' and delete fails buffer: \(client.string) marked: \(client.markedString()) app: \(self)"
+    )
+
+    inputKey(.space)
+    client.string = ""
+  }
 }

--- a/GureumTests/MockApp.swift
+++ b/GureumTests/MockApp.swift
@@ -7,117 +7,80 @@
 //
 
 import Foundation
+
 @testable import GureumCore
 
 class VirtualApp: NSObject {
-    let controller: MockInputController
-    let client = MockInputClient()
+  let controller: MockInputController
+  let client = MockInputClient()
 
-    override init() {
-        controller = MockInputController(server: InputMethodServer.shared.server, delegate: client, client: client)
-        super.init()
-    }
+  override init() {
+    controller = MockInputController(
+      server: InputMethodServer.shared.server, delegate: client, client: client)
+    super.init()
+  }
 
-    @discardableResult
-    func inputFlags(_ flags: NSEvent.ModifierFlags) -> Bool {
-        let processed = controller.inputFlags(Int(flags.rawValue), client: client)
-        controller.updateComposition()
-        return processed
-    }
+  @discardableResult
+  func inputFlags(_ flags: NSEvent.ModifierFlags) -> Bool {
+    let processed = controller.inputFlags(Int(flags.rawValue), client: client)
+    controller.updateComposition()
+    return processed
+  }
 
-    @discardableResult
-    func inputText(_ string: String!, key keyCode: KeyCode, modifiers flags: NSEvent.ModifierFlags = NSEvent.ModifierFlags(rawValue: 0)) -> Bool {
-        let processed = controller.inputText(string, key: keyCode.rawValue, modifiers: Int(flags.rawValue), client: client)
-        controller.updateComposition()
-        return processed
-    }
+  @discardableResult
+  func inputText(
+    _ string: String!, key keyCode: KeyCode,
+    modifiers flags: NSEvent.ModifierFlags = NSEvent.ModifierFlags(rawValue: 0)
+  ) -> Bool {
+    let processed = controller.inputText(
+      string, key: keyCode.rawValue, modifiers: Int(flags.rawValue), client: client)
+    controller.updateComposition()
+    return processed
+  }
 
-    @discardableResult
-    func inputDelete() -> Bool {
-        inputText("", key: .delete)
-    }
+  @discardableResult
+  func inputDelete() -> Bool {
+    inputText("", key: .delete)
+  }
 
-    @discardableResult
-    func inputKey(_ keyCode: KeyCode, modifiers flags: NSEvent.ModifierFlags = NSEvent.ModifierFlags(rawValue: 0)) -> Bool {
-        var string: String?
-        if keyCode.isKeyMappable {
-            string = KeyMapLower[keyCode.rawValue]
-            if !flags.intersection([.shift]).isEmpty {
-                string = KeyMapUpper[keyCode.rawValue]
-            }
-        } else if keyCode == .delete {
-            string = ""
-        }
-        return inputText(string, key: keyCode, modifiers: flags)
+  @discardableResult
+  func inputKey(
+    _ keyCode: KeyCode, modifiers flags: NSEvent.ModifierFlags = NSEvent.ModifierFlags(rawValue: 0)
+  ) -> Bool {
+    var string: String?
+    if keyCode.isKeyMappable {
+      string = keyMapLower[keyCode.rawValue]
+      if !flags.intersection([.shift]).isEmpty {
+        string = keyMapUpper[keyCode.rawValue]
+      }
+    } else if keyCode == .delete {
+      string = ""
     }
+    return inputText(string, key: keyCode, modifiers: flags)
+  }
 
-    func inputKeys(_ keys: String) {
-        for c in keys {
-            let (keyCode, modifiers) = KeyMapReversed["\(c)"]!
-            inputKey(keyCode, modifiers: modifiers)
-        }
+  func inputKeys(_ keys: String) {
+    for c in keys {
+      let (keyCode, modifiers) = keyMapReversed["\(c)"]!
+      inputKey(keyCode, modifiers: modifiers)
     }
+  }
 }
 
 class ModerateApp: VirtualApp {
-    override func inputText(_ string: String!, key keyCode: KeyCode, modifiers flags: NSEvent.ModifierFlags) -> Bool {
-        let processed = super.inputText(string, key: keyCode, modifiers: flags)
-        let specialFlags = flags.intersection([.command, .control])
+  override func inputText(
+    _ string: String!, key keyCode: KeyCode, modifiers flags: NSEvent.ModifierFlags
+  ) -> Bool {
+    let processed = super.inputText(string, key: keyCode, modifiers: flags)
+    let specialFlags = flags.intersection([.command, .control])
 
-        if !processed {
-            if specialFlags.isEmpty, string ?? "" != "" {
-                client.insertText(string, replacementRange: client.markedRange())
-            } else if keyCode == .delete, !client.string.isEmpty {
-                client.string.removeLast()
-            }
-        }
-        return processed
+    if !processed {
+      if specialFlags.isEmpty, string ?? "" != "" {
+        client.insertText(string, replacementRange: client.markedRange())
+      } else if keyCode == .delete, !client.string.isEmpty {
+        client.string.removeLast()
+      }
     }
+    return processed
+  }
 }
-
-/*
- @implementation TerminalApp
-
- - (BOOL)inputText:(NSString *)text key:(NSInteger)keyCode modifiers:(NSEventModifierFlags)flags {
- BOOL processed = NO;
- if (self.client.hasMarkedText) {
-     processed = [super inputText:text key:keyCode modifiers:flags];
-     if (keyCode == 36) {
-         processed = YES;
-     }
- }
- else {
-     if (keyCode == 36) {
-         [self.client insertText:text];
-         processed = YES;
-     } else {
-         processed = [super inputText:text key:keyCode modifiers:flags];
-     }
- }
- if (!processed) {
-     [self.client insertText:text replacementRange:self.client.markedRange];
- }
- return processed;
- }
-
- @end
-
- @implementation GreedyApp
-
- - (BOOL)inputText:(NSString *)text key:(NSInteger)keyCode modifiers:(NSEventModifierFlags)flags {
- BOOL processed = NO;
- if (self.client.hasMarkedText) {
-     processed = [super inputText:text key:keyCode modifiers:flags];
- }
- else {
-     processed = [super inputText:text key:keyCode modifiers:flags];
-     if (self.client.markedRange.length == 0 || !processed) {
-         // FIXME: Commited string should be removed too.
-         [self.client insertText:text replacementRange:self.client.markedRange];
-     }
- }
- return processed;
- }
-
- @end
- */

--- a/HACKING.md
+++ b/HACKING.md
@@ -115,11 +115,11 @@ sudo gem install xcpretty
 - Firefox.app : 단축키 입력을 선점하지 않습니다. Modifier를 수정했다면 테스트해 보아야 합니다.
 - MS 오피스 2011 : 화살표 키 등 일부 다른 프로그램에서는 전달하지 않는 키코드가 전달됩니다. (issue #3)
 
-### swiftformat 실행
+### swift-format 실행
 
-변경한 소스 코드에 대해 swiftformat을 실행하여 코드의 일관성을 유지해 주세요.
+변경한 소스 코드에 대해 swift-format을 실행하여 코드의 일관성을 유지해 주세요. swift-format은 Xcode(Swift 툴체인)에 기본 포함되어 있습니다.
 
-CI 과정에서 swiftformat으로 인한 변경 사항이 발견되면 빌드는 통과되지 않습니다.
+CI 과정에서 swift-format lint를 통과하지 못하는 변경 사항이 있으면 빌드는 통과되지 않습니다.
 
 ```sh
 make format

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all:
 	@echo 'Available commands:'
 	@echo '    init         -- setup a development environment'
-	@echo '    format       -- format code style with swiftformat'
+	@echo '    format       -- format code style with swift-format'
 	@echo '    xcode-select -- set the active developer directory to Xcode'
 	@echo '    brew-install -- install required Homebrew formulae'
 	@echo '    gem-install  -- install required gems'
@@ -10,7 +10,7 @@ init: xcode-select brew-install gem-install
 	git submodule update --init --recursive
 
 format:
-	swiftformat OSXCore/ OSX/ GureumTests/ Preferences/ OSXTestApp/
+	swift format --in-place --recursive OSXCore OSX GureumTests Preferences OSXTestApp
 
 xcode-select:
 	@if [ "$(shell xcode-select -p)" = '/Library/Developer/CommandLineTools' ]; then \
@@ -23,10 +23,6 @@ brew-install:
 	@if ! command -v shellcheck >/dev/null; then \
 		echo 'brew install shellcheck'; \
 		brew install shellcheck; \
-	fi
-	@if ! command -v swiftformat >/dev/null; then \
-		echo 'brew install swiftformat'; \
-		brew install swiftformat; \
 	fi
 
 gem-install:

--- a/OSX/AnswersHelper.swift
+++ b/OSX/AnswersHelper.swift
@@ -9,37 +9,37 @@
 import GureumCore
 
 @objc class AnswersHelper: NSObject {
-    let configuration = Configuration.shared
-    let launchedTime = Date()
+  let configuration = Configuration.shared
+  let launchedTime = Date()
 
-    func logLaunch() {
-//        let report = configuration.persistentDomain().mapValues { "\($0)" }
-//        Answers.logLogin(withMethod: "Launch",
-//                         success: true,
-//                         customAttributes: report)
-    }
+  func logLaunch() {
+    //        let report = configuration.persistentDomain().mapValues { "\($0)" }
+    //        Answers.logLogin(withMethod: "Launch",
+    //                         success: true,
+    //                         customAttributes: report)
+  }
 
-    @objc func logUptime() {
-//        let uptime = -launchedTime.timeIntervalSinceNow
-//        Answers.logContentView(withName: "Uptime",
-//                               contentType: "Indicator",
-//                               contentId: "uptime",
-//                               customAttributes: ["uptime": uptime])
-    }
+  @objc func logUptime() {
+    //        let uptime = -launchedTime.timeIntervalSinceNow
+    //        Answers.logContentView(withName: "Uptime",
+    //                               contentType: "Indicator",
+    //                               contentId: "uptime",
+    //                               customAttributes: ["uptime": uptime])
+  }
 
-    func logMenu(name _: String) {
-//        Answers.logContentView(withName: "Menu",
-//                               contentType: "Indicator",
-//                               contentId: "menu-\(name)",
-//                               customAttributes: ["name": name])
-    }
+  func logMenu(name _: String) {
+    //        Answers.logContentView(withName: "Menu",
+    //                               contentType: "Indicator",
+    //                               contentId: "menu-\(name)",
+    //                               customAttributes: ["name": name])
+  }
 
-    func logUpdateNotification(updating _: Bool) {
-//        Answers.logContentView(withName: "Notification",
-//                               contentType: "Indicator",
-//                               contentId: "update-\(updating)",
-//                               customAttributes: ["updating": updating])
-    }
+  func logUpdateNotification(updating _: Bool) {
+    //        Answers.logContentView(withName: "Notification",
+    //                               contentType: "Indicator",
+    //                               contentId: "update-\(updating)",
+    //                               customAttributes: ["updating": updating])
+  }
 }
 
 let answers = AnswersHelper()

--- a/OSX/ConfigurationWindow.swift
+++ b/OSX/ConfigurationWindow.swift
@@ -12,56 +12,60 @@ import Foundation
 final class ConfiguraionWindowController: NSWindowController {}
 
 final class PreferencePaneViewController: NSViewController {
-    private let _isAtLeast10_15 = ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 10, minorVersion: 15, patchVersion: 0))
+  private let isAtLeast1015 = ProcessInfo().isOperatingSystemAtLeast(
+    OperatingSystemVersion(majorVersion: 10, minorVersion: 15, patchVersion: 0))
 
-    func viewForFailure() -> NSView {
-        let rect = NSRect(x: 0, y: 0, width: 200, height: 100)
-        let label = NSTextView(frame: rect)
-        label.isEditable = false
-        label.string = "환경설정 GUI 읽기에 실패했습니다. 버그 리포트를 남겨주세요.\n\nhttps://github.com/gureum/gureum/issues"
-        let view = NSView(frame: rect)
-        view.addSubview(label)
-        return view
-    }
+  func viewForFailure() -> NSView {
+    let rect = NSRect(x: 0, y: 0, width: 200, height: 100)
+    let label = NSTextView(frame: rect)
+    label.isEditable = false
+    label.string = "환경설정 GUI 읽기에 실패했습니다. 버그 리포트를 남겨주세요.\n\nhttps://github.com/gureum/gureum/issues"
+    let view = NSView(frame: rect)
+    view.addSubview(label)
+    return view
+  }
 
-    func viewFromPrefPane() -> NSView {
-        let path = Bundle.main.path(forResource: "Preferences", ofType: "prefPane")
-        let bundle = NSPrefPaneBundle(path: path)!
-        guard bundle.bundle != nil, bundle.bundle.principalClass != nil else {
-            return viewForFailure()
-        }
-        if _isAtLeast10_15 {
-            let pane = NSPreferencePane(bundle: bundle.bundle)
-            return pane.loadMainView()
-        } else {
-            let loaded = bundle.instantiatePrefPaneObject()
-            assert(loaded)
-            let pane = bundle.prefPaneObject()!
-            return pane.mainView
-        }
+  func viewFromPrefPane() -> NSView {
+    let path = Bundle.main.path(forResource: "Preferences", ofType: "prefPane")
+    let bundle = NSPrefPaneBundle(path: path)!
+    guard bundle.bundle != nil, bundle.bundle.principalClass != nil else {
+      return viewForFailure()
     }
+    if isAtLeast1015 {
+      let pane = NSPreferencePane(bundle: bundle.bundle)
+      return pane.loadMainView()
+    } else {
+      let loaded = bundle.instantiatePrefPaneObject()
+      assert(loaded)
+      let pane = bundle.prefPaneObject()!
+      return pane.mainView
+    }
+  }
 
-    func viewFromNib() -> NSView {
-        var topLevelObjects: NSArray?
-        let succeed = Bundle.main.loadNibNamed("Preferences", owner: self, topLevelObjects: &topLevelObjects)
-        guard let nibObjects = topLevelObjects, succeed else {
-            NSLog("Preferences nib loading failed.")
-            return viewForFailure()
-        }
-        guard let vc = nibObjects.filter({
-            ($0 as! NSObject).className == "PreferenceViewController"
-        }).first as? PreferenceViewController else {
-            NSLog("Preferences lookup failed.")
-            return viewForFailure()
-        }
-        return vc.view
+  func viewFromNib() -> NSView {
+    var topLevelObjects: NSArray?
+    let succeed = Bundle.main.loadNibNamed(
+      "Preferences", owner: self, topLevelObjects: &topLevelObjects)
+    guard let nibObjects = topLevelObjects, succeed else {
+      NSLog("Preferences nib loading failed.")
+      return viewForFailure()
     }
+    guard
+      let vc = nibObjects.filter({
+        ($0 as! NSObject).className == "PreferenceViewController"
+      }).first as? PreferenceViewController
+    else {
+      NSLog("Preferences lookup failed.")
+      return viewForFailure()
+    }
+    return vc.view
+  }
 
-    override func loadView() {
-        #if USE_PREFPANE
-            view = viewFromPrefPane()
-        #else
-            view = viewFromNib()
-        #endif
-    }
+  override func loadView() {
+    #if USE_PREFPANE
+      view = viewFromPrefPane()
+    #else
+      view = viewFromNib()
+    #endif
+  }
 }

--- a/OSX/GureumAppDelegate.swift
+++ b/OSX/GureumAppDelegate.swift
@@ -13,74 +13,76 @@ import GureumCore
 import Hangul
 
 class NotificationCenterDelegate: NSObject, NSUserNotificationCenterDelegate {
-    static let appDefault = NotificationCenterDelegate()
+  static let appDefault = NotificationCenterDelegate()
 
-    func userNotificationCenter(_: NSUserNotificationCenter, didActivate notification: NSUserNotification) {
-        guard let userInfo = notification.userInfo else {
-            return
-        }
-        guard let download = userInfo["url"] as? String else {
-            return
-        }
-        var updating = false
-        switch notification.activationType {
-        case .actionButtonClicked:
-            fallthrough
-        case .contentsClicked:
-            updating = true
-        default:
-            break
-        }
-        if updating {
-            NSWorkspace.shared.open(URL(string: download)!)
-        }
-        answers.logUpdateNotification(updating: updating)
+  func userNotificationCenter(
+    _: NSUserNotificationCenter, didActivate notification: NSUserNotification
+  ) {
+    guard let userInfo = notification.userInfo else {
+      return
     }
+    guard let download = userInfo["url"] as? String else {
+      return
+    }
+    var updating = false
+    switch notification.activationType {
+    case .actionButtonClicked, .contentsClicked:
+      updating = true
+    default:
+      break
+    }
+    if updating {
+      NSWorkspace.shared.open(URL(string: download)!)
+    }
+    answers.logUpdateNotification(updating: updating)
+  }
 }
 
 class GureumAppDelegate: NSObject, NSApplicationDelegate, GureumApplicationDelegate {
-    @IBOutlet var menu: NSMenu!
+  @IBOutlet var menu: NSMenu!
 
-    let configuration = Configuration.shared
-    let notificationCenterDelegate = NotificationCenterDelegate()
+  let configuration = Configuration.shared
+  let notificationCenterDelegate = NotificationCenterDelegate()
 
-    func applicationDidFinishLaunching(_: Notification) {
-        FirebaseApp.configure()
-        UserDefaults.standard.register(defaults: ["NSApplicationCrashOnExceptions": true])
+  func applicationDidFinishLaunching(_: Notification) {
+    FirebaseApp.configure()
+    UserDefaults.standard.register(defaults: ["NSApplicationCrashOnExceptions": true])
 
-        NSUserNotificationCenter.default.delegate = notificationCenterDelegate
-        let notificationCenter = NSUserNotificationCenter.default
-        #if DEBUG
-            let notification = NSUserNotification()
-            notification.title = "디버그 빌드 알림"
-            notification.hasActionButton = false
-            notification.hasReplyButton = false
-            notification.informativeText = "이 버전은 디버그 빌드입니다. 키 입력이 로그로 남을 수 있어 안전하지 않습니다."
-            notificationCenter.deliver(notification)
-            // Fabric.with([Answers.self])
-            preferencesWindow.showWindow(nil)
-        #else
-            // Fabric.with([Crashlytics.self, Answers.self])
-        #endif
+    NSUserNotificationCenter.default.delegate = notificationCenterDelegate
+    let notificationCenter = NSUserNotificationCenter.default
+    #if DEBUG
+      let notification = NSUserNotification()
+      notification.title = "디버그 빌드 알림"
+      notification.hasActionButton = false
+      notification.hasReplyButton = false
+      notification.informativeText = "이 버전은 디버그 빌드입니다. 키 입력이 로그로 남을 수 있어 안전하지 않습니다."
+      notificationCenter.deliver(notification)
+      // Fabric.with([Answers.self])
+      preferencesWindow.showWindow(nil)
+    #else
+      // Fabric.with([Crashlytics.self, Answers.self])
+    #endif
 
-        UpdateManager.shared.notifyUpdateIfNeeded()
+    UpdateManager.shared.notifyUpdateIfNeeded()
 
-        // 입력 모니터링 권한 요청
-        if #available(macOS 10.15, *) {
-            IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)
-        }
-
-        // IMKServer를 띄워야만 입력기가 동작한다
-        _ = InputMethodServer.shared
-
-        answers.logLaunch()
-
-        Timer.scheduledTimer(timeInterval: 3600, target: answers, selector: #selector(AnswersHelper.logUptime), userInfo: nil, repeats: true)
-        // for 10.12+
-        // Timer.scheduledTimer(withTimeInterval: 3600, repeats: true) { _ in
-        //   answers.logUptime()
-        // }
-
-        watcher.reloadConfiguration()
+    // 입력 모니터링 권한 요청
+    if #available(macOS 10.15, *) {
+      IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)
     }
+
+    // IMKServer를 띄워야만 입력기가 동작한다
+    _ = InputMethodServer.shared
+
+    answers.logLaunch()
+
+    Timer.scheduledTimer(
+      timeInterval: 3600, target: answers, selector: #selector(AnswersHelper.logUptime),
+      userInfo: nil, repeats: true)
+    // for 10.12+
+    // Timer.scheduledTimer(withTimeInterval: 3600, repeats: true) { _ in
+    //   answers.logUptime()
+    // }
+
+    watcher.reloadConfiguration()
+  }
 }

--- a/OSX/GureumMenu.swift
+++ b/OSX/GureumMenu.swift
@@ -10,104 +10,107 @@ import Cocoa
 import Foundation
 import GureumCore
 
-let preferencesWindow: NSWindowController = NSStoryboard(name: "Configuration", bundle: Bundle.main).instantiateInitialController() as! NSWindowController
+let preferencesWindow: NSWindowController =
+  NSStoryboard(name: "Configuration", bundle: Bundle.main).instantiateInitialController()
+  as! NSWindowController
 
 // 왜 App delegate가 아니라 여기 붙는건지 모르겠다
 extension InputController {
-    @IBAction func showStandardAboutPanel(_ sender: Any) {
-        NSApp.activate(ignoringOtherApps: true)
-        NSApp.orderFrontStandardAboutPanel(sender)
-        answers.logMenu(name: "about")
-    }
+  @IBAction func showStandardAboutPanel(_ sender: Any) {
+    NSApp.activate(ignoringOtherApps: true)
+    NSApp.orderFrontStandardAboutPanel(sender)
+    answers.logMenu(name: "about")
+  }
 
-    @IBAction func showPreferencesWindow(_: Any) {
-        NSApp.activate(ignoringOtherApps: true)
-        preferencesWindow.showWindow(nil)
-    }
+  @IBAction func showPreferencesWindow(_: Any) {
+    NSApp.activate(ignoringOtherApps: true)
+    preferencesWindow.showWindow(nil)
+  }
 
-    private func checkVersion(mode: UpdateMode) {
-        var title = ""
-        var version = ""
-        switch mode {
-        case .Stable:
-            title = "업데이트"
-            version = "버전"
-        case .Experimental:
-            title = "실험 버전"
-            version = "실험 버전"
+  private func checkVersion(mode: UpdateMode) {
+    var title = ""
+    var version = ""
+    switch mode {
+    case .stable:
+      title = "업데이트"
+      version = "버전"
+    case .experimental:
+      title = "실험 버전"
+      version = "실험 버전"
+    }
+    UpdateManager.shared.requestVersionInfo(mode: mode) { info in
+      guard let info = info else {
+        let alert = NSAlert()
+        alert.messageText = "구름 입력기 \(title) 확인"
+        alert.addButton(withTitle: "확인")
+        alert.informativeText = "\(title) 정보에 접근할 수 없습니다. 인터넷에 연결되어 있지 않거나 구름 업데이트의 버그일 수 있습니다."
+        alert.runModal()
+        return
+      }
+      if info.update.version == info.current {
+        let fmt = "현재 사용하고 있는 구름 입력기 \(info.current ?? "-") 는 최신 \(version)입니다."
+        let alert = NSAlert()
+        alert.messageText = "구름 입력기 \(title) 확인"
+        alert.addButton(withTitle: "확인")
+        alert.informativeText = fmt
+        alert.runModal()
+      } else {
+        var message =
+          "현재 사용하고 있는 구름 입력기는 \(info.current ?? "-") 이고 최신 \(version)은 \(info.update.version) 입니다. 업데이트는 로그아웃하거나 재부팅해야 적용됩니다."
+        if !info.update.description.isEmpty {
+          message += " 업데이트 요약은 '\(info.update.description)' 입니다."
         }
-        UpdateManager.shared.requestVersionInfo(mode: mode) { info in
-            guard let info = info else {
-                let alert = NSAlert()
-                alert.messageText = "구름 입력기 \(title) 확인"
-                alert.addButton(withTitle: "확인")
-                alert.informativeText = "\(title) 정보에 접근할 수 없습니다. 인터넷에 연결되어 있지 않거나 구름 업데이트의 버그일 수 있습니다."
-                alert.runModal()
-                return
-            }
-            if info.update.version == info.current {
-                let fmt = "현재 사용하고 있는 구름 입력기 \(info.current ?? "-") 는 최신 \(version)입니다."
-                let alert = NSAlert()
-                alert.messageText = "구름 입력기 \(title) 확인"
-                alert.addButton(withTitle: "확인")
-                alert.informativeText = fmt
-                alert.runModal()
-            } else {
-                var message = "현재 사용하고 있는 구름 입력기는 \(info.current ?? "-") 이고 최신 \(version)은 \(info.update.version) 입니다. 업데이트는 로그아웃하거나 재부팅해야 적용됩니다."
-                if !info.update.description.isEmpty {
-                    message += " 업데이트 요약은 '\(info.update.description)' 입니다."
-                }
-                if let url = URL(string: info.update.url) {
-                    NSWorkspace.shared.open(url)
-                } else {
-                    message += " 현재 업데이트 링크를 찾을 수 없습니다. 버그 리포트를 부탁드립니다."
-                }
-                let alert = NSAlert()
-                alert.messageText = "구름 입력기 \(title) 확인"
-                alert.addButton(withTitle: "확인")
-                alert.informativeText = message
-                alert.runModal()
-            }
+        if let url = URL(string: info.update.url) {
+          NSWorkspace.shared.open(url)
+        } else {
+          message += " 현재 업데이트 링크를 찾을 수 없습니다. 버그 리포트를 부탁드립니다."
         }
+        let alert = NSAlert()
+        alert.messageText = "구름 입력기 \(title) 확인"
+        alert.addButton(withTitle: "확인")
+        alert.informativeText = message
+        alert.runModal()
+      }
     }
+  }
 
-    @IBAction func checkRecentVersion(_: Any) {
-        answers.logMenu(name: "check-version")
-        checkVersion(mode: .Stable)
-    }
+  @IBAction func checkRecentVersion(_: Any) {
+    answers.logMenu(name: "check-version")
+    checkVersion(mode: .stable)
+  }
 
-    @IBAction func checkExperimentalVersion(_: Any) {
-        answers.logMenu(name: "check-experimental")
-        checkVersion(mode: .Experimental)
-    }
+  @IBAction func checkExperimentalVersion(_: Any) {
+    answers.logMenu(name: "check-experimental")
+    checkVersion(mode: .experimental)
+  }
 
-    @IBAction func openWebsite(_: Any) {
-        let url = URL(string: "http://gureum.io")!
-        NSWorkspace.shared.open(url)
-        answers.logMenu(name: "website")
-    }
+  @IBAction func openWebsite(_: Any) {
+    let url = URL(string: "http://gureum.io")!
+    NSWorkspace.shared.open(url)
+    answers.logMenu(name: "website")
+  }
 
-    @IBAction func openWebsiteHelp(_: Any) {
-        let url = URL(string: "http://dan.gureum.io")!
-        NSWorkspace.shared.open(url)
-        answers.logMenu(name: "website-help")
-    }
+  @IBAction func openWebsiteHelp(_: Any) {
+    let url = URL(string: "http://dan.gureum.io")!
+    NSWorkspace.shared.open(url)
+    answers.logMenu(name: "website-help")
+  }
 
-    @IBAction func openWebsiteSource(_: Any) {
-        let url = URL(string: "http://ssi.gureum.io")!
-        NSWorkspace.shared.open(url)
-        answers.logMenu(name: "website-source")
-    }
+  @IBAction func openWebsiteSource(_: Any) {
+    let url = URL(string: "http://ssi.gureum.io")!
+    NSWorkspace.shared.open(url)
+    answers.logMenu(name: "website-source")
+  }
 
-    @IBAction func openWebsiteIssues(_: Any) {
-        let url = URL(string: "http://meok.gureum.io")!
-        NSWorkspace.shared.open(url)
-        answers.logMenu(name: "website-issues")
-    }
+  @IBAction func openWebsiteIssues(_: Any) {
+    let url = URL(string: "http://meok.gureum.io")!
+    NSWorkspace.shared.open(url)
+    answers.logMenu(name: "website-issues")
+  }
 
-    @IBAction func openWebsiteDonation(_: Any) {
-        let url = URL(string: "http://donation.gureum.io")!
-        NSWorkspace.shared.open(url)
-        answers.logMenu(name: "website-donation")
-    }
+  @IBAction func openWebsiteDonation(_: Any) {
+    let url = URL(string: "http://donation.gureum.io")!
+    NSWorkspace.shared.open(url)
+    answers.logMenu(name: "website-donation")
+  }
 }

--- a/OSX/TISInputSource.swift
+++ b/OSX/TISInputSource.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension TISInputSource {
-    override open var description: String {
-        "<(self.class.name)(((self.identifier)))>"
-    }
+  override open var description: String {
+    "<(self.class.name)(((self.identifier)))>"
+  }
 }

--- a/OSX/UpdateManager.swift
+++ b/OSX/UpdateManager.swift
@@ -11,83 +11,84 @@ import Foundation
 import GureumCore
 
 class UpdateManager {
-    static let shared = UpdateManager()
+  static let shared = UpdateManager()
 
-    struct UpdateInfo: Decodable {
-        let version: String
-        let description: String
-        let url: String
+  struct UpdateInfo: Decodable {
+    let version: String
+    let description: String
+    let url: String
 
-        enum CodingKeys: String, CodingKey {
-            case version
-            case description
-            case url
-        }
+    enum CodingKeys: String, CodingKey {
+      case version
+      case description
+      case url
     }
+  }
 
-    struct VersionInfo {
-        let current: String? = Bundle.main.version
-        let update: UpdateInfo
-        let experimental: Bool
+  struct VersionInfo {
+    let current: String? = Bundle.main.version
+    let update: UpdateInfo
+    let experimental: Bool
+  }
+
+  func requestVersionInfo(mode: UpdateMode, _ done: @escaping ((VersionInfo?) -> Void)) {
+    let url: URL
+    switch mode {
+    case .stable:
+      url = URL(string: "https://gureum.io/version.json")!
+    case .experimental:
+      url = URL(string: "https://gureum.io/version-experimental.json")!
     }
+    var urlRequest = URLRequest(url: url)
+    urlRequest.timeoutInterval = 1.0
+    urlRequest.cachePolicy = .reloadIgnoringCacheData
 
-    func requestVersionInfo(mode: UpdateMode, _ done: @escaping ((VersionInfo?) -> Void)) {
-        let url: URL
-        switch mode {
-        case .Stable:
-            url = URL(string: "https://gureum.io/version.json")!
-        case .Experimental:
-            url = URL(string: "https://gureum.io/version-experimental.json")!
-        }
-        var urlRequest = URLRequest(url: url)
-        urlRequest.timeoutInterval = 1.0
-        urlRequest.cachePolicy = .reloadIgnoringCacheData
-
-        let request = AF.request(urlRequest)
-//        request.responseJSON {
-//            data in
-//            print("data!", data)
-//        }
-        request.validate().responseDecodable(of: UpdateInfo.self) { response in
-            guard let update = response.value else { return done(nil) }
-            let version = VersionInfo(update: update, experimental: mode == .Experimental)
-            done(version)
-        }
+    let request = AF.request(urlRequest)
+    //        request.responseJSON {
+    //            data in
+    //            print("data!", data)
+    //        }
+    request.validate().responseDecodable(of: UpdateInfo.self) { response in
+      guard let update = response.value else { return done(nil) }
+      let version = VersionInfo(update: update, experimental: mode == .experimental)
+      done(version)
     }
+  }
 
-    func requestAutoUpdateVersionInfo(_ done: @escaping ((VersionInfo?) -> Void)) {
-        guard let mode = Configuration.shared.updateMode else {
-            return
-        }
-        requestVersionInfo(mode: mode, done)
+  func requestAutoUpdateVersionInfo(_ done: @escaping ((VersionInfo?) -> Void)) {
+    guard let mode = Configuration.shared.updateMode else {
+      return
     }
+    requestVersionInfo(mode: mode, done)
+  }
 
-    class func notifyUpdate(info: VersionInfo) {
-        let notification = NSUserNotification()
-        var title = "구름 입력기 업데이트 알림"
-        if info.experimental {
-            title += " (실험 버전)"
-        }
-        notification.title = title
-        notification.hasActionButton = true
-        notification.hasReplyButton = false
-        notification.actionButtonTitle = "업데이트"
-        notification.otherButtonTitle = "취소"
-        notification.informativeText = "최신 버전: \(info.update.version) 현재 버전: \(info.current ?? "-")\n\(info.update.description)"
-        notification.userInfo = ["url": info.update.url]
-
-        NSUserNotificationCenter.default.deliver(notification)
+  class func notifyUpdate(info: VersionInfo) {
+    let notification = NSUserNotification()
+    var title = "구름 입력기 업데이트 알림"
+    if info.experimental {
+      title += " (실험 버전)"
     }
+    notification.title = title
+    notification.hasActionButton = true
+    notification.hasReplyButton = false
+    notification.actionButtonTitle = "업데이트"
+    notification.otherButtonTitle = "취소"
+    notification.informativeText =
+      "최신 버전: \(info.update.version) 현재 버전: \(info.current ?? "-")\n\(info.update.description)"
+    notification.userInfo = ["url": info.update.url]
 
-    func notifyUpdateIfNeeded() {
-        requestAutoUpdateVersionInfo { info in
-            guard let info = info else {
-                return
-            }
-            guard info.update.version != info.current else {
-                return
-            }
-            UpdateManager.notifyUpdate(info: info)
-        }
+    NSUserNotificationCenter.default.deliver(notification)
+  }
+
+  func notifyUpdateIfNeeded() {
+    requestAutoUpdateVersionInfo { info in
+      guard let info = info else {
+        return
+      }
+      guard info.update.version != info.current else {
+        return
+      }
+      UpdateManager.notifyUpdate(info: info)
     }
+  }
 }

--- a/OSX/main.swift
+++ b/OSX/main.swift
@@ -13,7 +13,7 @@ import Cocoa
 let mainNibName = Bundle.main.infoDictionary!["NSMainNibFile"] as! String
 let nib = NSNib(nibNamed: NSNib.Name(mainNibName), bundle: Bundle.main)!
 if nib.instantiate(withOwner: NSApplication.shared, topLevelObjects: nil) == false {
-    dlog(true, "!! Gureum fails to load Main Nib File !!")
+  dlog(true, "!! Gureum fails to load Main Nib File !!")
 }
 
 dlog(true, "****   Main bundle \(mainNibName) loaded   ****")

--- a/OSXCore/BundleVersion.swift
+++ b/OSXCore/BundleVersion.swift
@@ -8,15 +8,15 @@
 
 import Foundation
 
-public extension Bundle {
-    var version: String? {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
-    }
+extension Bundle {
+  public var version: String? {
+    Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+  }
 
-    var isExperimental: Bool {
-        guard let current = version else {
-            return false
-        }
-        return current.contains("-experimental") || current.contains("-rc")
+  public var isExperimental: Bool {
+    guard let current = version else {
+      return false
     }
+    return current.contains("-experimental") || current.contains("-rc")
+  }
 }

--- a/OSXCore/Composer.swift
+++ b/OSXCore/Composer.swift
@@ -15,23 +15,25 @@ import InputMethodKit
 /// `TextData` 형식으로 `IMKServerInput`을 처리할 클래스의 공통 인터페이스.
 /// 입력 값을 보고 처리하는 모든 클래스는 이 프로토콜을 구헌한다.
 protocol InputTextDelegate {
-    /// 입력을 수행한다.
-    ///
-    /// 기본적으로 델리게이트 객체의 `input(text:key:modifiers:client)` 메소드를 호출한다.
-    ///
-    /// - Parameters:
-    ///   - text: 문자열로 표현된 입력 값.
-    ///   - key: 입력된 키의 key code.
-    ///   - modifiers: 입력된 modifier flag.
-    ///   - client: 입력 값을 전달한 외부 오브젝트.
-    ///
-    /// - Returns: 입력 결과.
-    ///
-    /// - Note: 반환 값의 `processed`가 `true`이면 이미 처리된 입력으로 보고, `false`이면 외부에서 입력을 다시 처리한다.
-    func input(text: String?,
-               key: KeyCode,
-               modifiers: NSEvent.ModifierFlags,
-               client: IMKTextInput & IMKUnicodeTextInput) -> InputResult
+  /// 입력을 수행한다.
+  ///
+  /// 기본적으로 델리게이트 객체의 `input(text:key:modifiers:client)` 메소드를 호출한다.
+  ///
+  /// - Parameters:
+  ///   - text: 문자열로 표현된 입력 값.
+  ///   - key: 입력된 키의 key code.
+  ///   - modifiers: 입력된 modifier flag.
+  ///   - client: 입력 값을 전달한 외부 오브젝트.
+  ///
+  /// - Returns: 입력 결과.
+  ///
+  /// - Note: 반환 값의 `processed`가 `true`이면 이미 처리된 입력으로 보고, `false`이면 외부에서 입력을 다시 처리한다.
+  func input(
+    text: String?,
+    key: KeyCode,
+    modifiers: NSEvent.ModifierFlags,
+    client: IMKTextInput & IMKUnicodeTextInput
+  ) -> InputResult
 }
 
 /// 문자를 합성하는 합성기의 프로토콜.
@@ -39,139 +41,140 @@ protocol InputTextDelegate {
 /// 입력기 전체의 상태에 영향을 끼치는 처리를 마친 후 출력할 글자를 조합하기 위해 `DelegatedComposer`로 입력을 전달한다.
 /// 기본적으로 자판마다 하나씩 구현하게 된다.
 protocol Composer: InputTextDelegate {
-    /// 델리게이트 객체.
-    ///
-    /// 기본값은 `nil`이다.
-    var delegate: Composer! { get }
+  /// 델리게이트 객체.
+  ///
+  /// 기본값은 `nil`이다.
+  var delegate: Composer! { get }
 
-    /// 합성 중인 문자로 보여줄 문자열.
-    ///
-    /// 기본적으로 델리게이트 객체의 `composedString`을 반환한다.
-    var composedString: String { get }
+  /// 합성 중인 문자로 보여줄 문자열.
+  ///
+  /// 기본적으로 델리게이트 객체의 `composedString`을 반환한다.
+  var composedString: String { get }
 
-    /// 합성을 취소하면 사용할 문자열.
-    ///
-    /// 기본적으로 델리게이트 객체의 `originalString`을 반환한다.
-    var originalString: String { get }
+  /// 합성을 취소하면 사용할 문자열.
+  ///
+  /// 기본적으로 델리게이트 객체의 `originalString`을 반환한다.
+  var originalString: String { get }
 
-    /// 합성이 완료된 문자열.
-    ///
-    /// 기본적으로 델리게이트 객체의 `commitString`을 반환한다.
-    var commitString: String { get }
+  /// 합성이 완료된 문자열.
+  ///
+  /// 기본적으로 델리게이트 객체의 `commitString`을 반환한다.
+  var commitString: String { get }
 
-    /// 변환 후보 문자열 리스트.
-    ///
-    /// 기본적으로 델리게이트 객체의 `candidates`를 반환한다.
-    var candidates: [NSAttributedString]? { get }
+  /// 변환 후보 문자열 리스트.
+  ///
+  /// 기본적으로 델리게이트 객체의 `candidates`를 반환한다.
+  var candidates: [NSAttributedString]? { get }
 
-    /// 변환 후보 문자열 존재 여부.
-    ///
-    /// 기본적으로 델리게이트 객체의 `hasCandidates`를 반환한다.
-    var hasCandidates: Bool { get }
+  /// 변환 후보 문자열 존재 여부.
+  ///
+  /// 기본적으로 델리게이트 객체의 `hasCandidates`를 반환한다.
+  var hasCandidates: Bool { get }
 
-    /// 초기화 작업을 수행한다.
-    ///
-    /// 기본적으로 아무 동작도 하지 않는다.
-    func clear()
+  /// 초기화 작업을 수행한다.
+  ///
+  /// 기본적으로 아무 동작도 하지 않는다.
+  func clear()
 
-    /// 합성이 완료된 문자열(`commitString`)을 반환하며 비운다.
-    ///
-    /// 기본적으로 델리게이트 객체의 `dequeueCommitString()` 메소드의 실행 결과를 반환한다.
-    ///
-    /// - Returns: 합성이 완료된 문자열.
-    @discardableResult
-    func dequeueCommitString() -> String
+  /// 합성이 완료된 문자열(`commitString`)을 반환하며 비운다.
+  ///
+  /// 기본적으로 델리게이트 객체의 `dequeueCommitString()` 메소드의 실행 결과를 반환한다.
+  ///
+  /// - Returns: 합성이 완료된 문자열.
+  @discardableResult
+  func dequeueCommitString() -> String
 
-    /// 조합을 취소한다.
-    ///
-    /// 기본적으로 델리게이트 객체의 `cancelComposition()` 메소드를 호출한다.
-    func cancelComposition()
+  /// 조합을 취소한다.
+  ///
+  /// 기본적으로 델리게이트 객체의 `cancelComposition()` 메소드를 호출한다.
+  func cancelComposition()
 
-    /// 조합 문맥을 초기화한다.
-    ///
-    /// 기본적으로 델리게이트 객체의 `clearCompositionContext()` 메소드를 호출한다.
-    func clearCompositionContext()
+  /// 조합 문맥을 초기화한다.
+  ///
+  /// 기본적으로 델리게이트 객체의 `clearCompositionContext()` 메소드를 호출한다.
+  func clearCompositionContext()
 
-    /// 입력기가 선택되었을 때 수행할 작업을 정의한다.
-    ///
-    /// 기본적으로 아무 동작도 하지 않는다.
-    func composerSelected()
+  /// 입력기가 선택되었을 때 수행할 작업을 정의한다.
+  ///
+  /// 기본적으로 아무 동작도 하지 않는다.
+  func composerSelected()
 
-    /// 변환 후보 문자열이 선택된 후 수행할 작업을 정의한다.
-    ///
-    /// 기본적으로 델리게이트 객체의 `candidateSelected(_:)` 메소드를 호출한다.
-    ///
-    /// - Parameter candidateString: 선택된 후보 문자열.
-    func candidateSelected(_ candidateString: NSAttributedString)
+  /// 변환 후보 문자열이 선택된 후 수행할 작업을 정의한다.
+  ///
+  /// 기본적으로 델리게이트 객체의 `candidateSelected(_:)` 메소드를 호출한다.
+  ///
+  /// - Parameter candidateString: 선택된 후보 문자열.
+  func candidateSelected(_ candidateString: NSAttributedString)
 
-    /// 변환 후보 문자열이 변경된 후 수행할 작업을 정의한다.
-    ///
-    /// 기본적으로 델리게이트 객체의 `candidateSelectionChanged(_:)` 메소드를 호출한다.
-    ///
-    /// - Parameter candidateString: 선택된 후보 문자열.
-    func candidateSelectionChanged(_ candidateString: NSAttributedString)
+  /// 변환 후보 문자열이 변경된 후 수행할 작업을 정의한다.
+  ///
+  /// 기본적으로 델리게이트 객체의 `candidateSelectionChanged(_:)` 메소드를 호출한다.
+  ///
+  /// - Parameter candidateString: 선택된 후보 문자열.
+  func candidateSelectionChanged(_ candidateString: NSAttributedString)
 }
 
 // MARK: - Composer 프로토콜 초기 구현
 
 extension Composer {
-    var delegate: Composer! {
-        return nil
-    }
+  var delegate: Composer! {
+    return nil
+  }
 
-    var composedString: String {
-        return delegate.composedString
-    }
+  var composedString: String {
+    return delegate.composedString
+  }
 
-    var originalString: String {
-        return delegate.originalString
-    }
+  var originalString: String {
+    return delegate.originalString
+  }
 
-    var commitString: String {
-        return delegate.commitString
-    }
+  var commitString: String {
+    return delegate.commitString
+  }
 
-    var candidates: [NSAttributedString]? {
-        return delegate.candidates
-    }
+  var candidates: [NSAttributedString]? {
+    return delegate.candidates
+  }
 
-    var hasCandidates: Bool {
-        return delegate.hasCandidates
-    }
+  var hasCandidates: Bool {
+    return delegate.hasCandidates
+  }
 
-    func clear() {}
+  func clear() {}
 
-    func dequeueCommitString() -> String {
-        return delegate.dequeueCommitString()
-    }
+  func dequeueCommitString() -> String {
+    return delegate.dequeueCommitString()
+  }
 
-    func cancelComposition() {
-        delegate.cancelComposition()
-    }
+  func cancelComposition() {
+    delegate.cancelComposition()
+  }
 
-    func clearCompositionContext() {
-        delegate.clearCompositionContext()
-    }
+  func clearCompositionContext() {
+    delegate.clearCompositionContext()
+  }
 
-    func composerSelected() {}
+  func composerSelected() {}
 
-    func candidateSelected(_ candidateString: NSAttributedString) {
-        assert(delegate != nil)
-        delegate.candidateSelected(candidateString)
-    }
+  func candidateSelected(_ candidateString: NSAttributedString) {
+    assert(delegate != nil)
+    delegate.candidateSelected(candidateString)
+  }
 
-    func candidateSelectionChanged(_ candidateString: NSAttributedString) {
-        assert(delegate != nil)
-        delegate.candidateSelectionChanged(candidateString)
-    }
+  func candidateSelectionChanged(_ candidateString: NSAttributedString) {
+    assert(delegate != nil)
+    delegate.candidateSelectionChanged(candidateString)
+  }
 
-    // MARK: InputTextDelegate
+  // MARK: InputTextDelegate
 
-    func input(text: String?,
-               key: KeyCode,
-               modifiers: NSEvent.ModifierFlags,
-               client: IMKTextInput & IMKUnicodeTextInput) -> InputResult
-    {
-        return delegate.input(text: text, key: key, modifiers: modifiers, client: client)
-    }
+  func input(
+    text: String?,
+    key: KeyCode,
+    modifiers: NSEvent.ModifierFlags,
+    client: IMKTextInput & IMKUnicodeTextInput
+  ) -> InputResult {
+    return delegate.input(text: text, key: key, modifiers: modifiers, client: client)
+  }
 }

--- a/OSXCore/Configuration.swift
+++ b/OSXCore/Configuration.swift
@@ -11,306 +11,307 @@ import Foundation
 
 /// 환경 설정 이름을 정의한 열거형.
 enum ConfigurationName {
-    /// 마지막 한글 입력 모드.
-    public static let lastHangulInputMode = "LastHangulInputMode"
-    /// 마지막 로마자 입력 모드.
-    public static let lastRomanInputMode = "LastRomanInputMode"
+  /// 마지막 한글 입력 모드.
+  public static let lastHangulInputMode = "LastHangulInputMode"
+  /// 마지막 로마자 입력 모드.
+  public static let lastRomanInputMode = "LastRomanInputMode"
 
-    /// 입력기 바꾸기 단축키.
-    public static let inputModeExchangeKey = "InputModeExchangeKey"
-    /// 한자 및 이모지 검색 단축키.
-    public static let inputModeSearchKey = "InputModeHanjaKey"
-    /// 로마자로 바꾸기 단축키.
-    public static let inputModeEnglishKey = "InputModeEnglishKey"
-    /// 한글로 바꾸기 단축키.
-    public static let inputModeKoreanKey = "InputModeKoreanKey"
-    /// 옵션 키 동작.
-    public static let optionKeyBehavior = "OptionKeyBehavior"
-    /// 기본 키보드 레이아웃.
-    public static let overridingKeyboardName = "OverridingKeyboardName"
+  /// 입력기 바꾸기 단축키.
+  public static let inputModeExchangeKey = "InputModeExchangeKey"
+  /// 한자 및 이모지 검색 단축키.
+  public static let inputModeSearchKey = "InputModeHanjaKey"
+  /// 로마자로 바꾸기 단축키.
+  public static let inputModeEnglishKey = "InputModeEnglishKey"
+  /// 한글로 바꾸기 단축키.
+  public static let inputModeKoreanKey = "InputModeKoreanKey"
+  /// 옵션 키 동작.
+  public static let optionKeyBehavior = "OptionKeyBehavior"
+  /// 기본 키보드 레이아웃.
+  public static let overridingKeyboardName = "OverridingKeyboardName"
 
-    /// Esc 키로 로마자 자판으로 전환 (vi 모드).
-    public static let romanModeByEscapeKey = "ExchangeToRomanModeByEscapeKey"
-    /// 한글 입력기일 때 역따옴표(`)로 원화 기호(₩) 입력.
-    public static let hangulWonCurrencySymbolForBackQuote = "HangulWonCurrencySymbolForBackQuote"
-    /// 완성되지 않은 낱자 자동 교정 (모아치기).
-    public static let hangulAutoReorder = "HangulAutoReorder"
-    /// 두벌식 초성 조합 중에도 종성 결합 허용 (MS윈도 호환).
-    public static let hangulNonChoseongCombination = "HangulNonChoseongCombination"
-    /// 모든 글자를 조합 중인 글자로 취급 (JDK 호환).
-    public static let hangulDeferredSymbolCommit = "HangulDeferredSymbolCommit"
-    /// 세벌식 정석 강요.
-    public static let hangulForceStrictCombinationRule = "HangulForceStrictCombinationRule"
-    /// 우측 키로 언어 전환
-    public static let rightToggleKey = "RightToggleKey"
+  /// Esc 키로 로마자 자판으로 전환 (vi 모드).
+  public static let romanModeByEscapeKey = "ExchangeToRomanModeByEscapeKey"
+  /// 한글 입력기일 때 역따옴표(`)로 원화 기호(₩) 입력.
+  public static let hangulWonCurrencySymbolForBackQuote = "HangulWonCurrencySymbolForBackQuote"
+  /// 완성되지 않은 낱자 자동 교정 (모아치기).
+  public static let hangulAutoReorder = "HangulAutoReorder"
+  /// 두벌식 초성 조합 중에도 종성 결합 허용 (MS윈도 호환).
+  public static let hangulNonChoseongCombination = "HangulNonChoseongCombination"
+  /// 모든 글자를 조합 중인 글자로 취급 (JDK 호환).
+  public static let hangulDeferredSymbolCommit = "HangulDeferredSymbolCommit"
+  /// 세벌식 정석 강요.
+  public static let hangulForceStrictCombinationRule = "HangulForceStrictCombinationRule"
+  /// 우측 키로 언어 전환
+  public static let rightToggleKey = "RightToggleKey"
 
-    /// 업데이트 알림 받기
-    public static let updateNotification = "UpdateNotification"
-    /// 실험버전 업데이트 알림 받기
-    public static let updateNotificationExperimental = "UpdateNotificationExperimental"
+  /// 업데이트 알림 받기
+  public static let updateNotification = "UpdateNotification"
+  /// 실험버전 업데이트 알림 받기
+  public static let updateNotificationExperimental = "UpdateNotificationExperimental"
 }
 
 // MARK: - Configuration 클래스
 
 public enum UpdateMode {
-    case Stable
-    case Experimental
+  case stable
+  case experimental
 }
 
 /// 입력기의 환경 설정을 담당하는 오브젝트.
 public class Configuration: UserDefaults {
-    public static let sharedSuiteName = "org.youknowone.Gureum"
-    public static var shared = Configuration()
+  public static let sharedSuiteName = "org.youknowone.Gureum"
+  public static var shared = Configuration()
 
-    var enableCapslockToToggleInputMode: Bool = false
+  var enableCapslockToToggleInputMode: Bool = false
 
-    public typealias Shortcut = (KeyCode, NSEvent.ModifierFlags)
+  public typealias Shortcut = (KeyCode, NSEvent.ModifierFlags)
 
-    class func convertShortcutToConfiguration(_ shortcut: Shortcut?) -> [String: Any] {
-        guard let shortcut = shortcut else {
-            return [:]
-        }
-        return ["modifier": shortcut.1.rawValue, "keyCode": shortcut.0.rawValue]
+  class func convertShortcutToConfiguration(_ shortcut: Shortcut?) -> [String: Any] {
+    guard let shortcut = shortcut else {
+      return [:]
     }
+    return ["modifier": shortcut.1.rawValue, "keyCode": shortcut.0.rawValue]
+  }
 
-    class func convertConfigurationToShortcut(_ configuration: [String: Any]) -> Shortcut? {
-        guard let modifier = configuration["modifier"] as? UInt,
-              let keyCodeRawValue = configuration["keyCode"] as? Int,
-              let keyCode = KeyCode(rawValue: keyCodeRawValue)
-        else {
-            return nil
-        }
-        return (keyCode, NSEvent.ModifierFlags(rawValue: modifier))
+  class func convertConfigurationToShortcut(_ configuration: [String: Any]) -> Shortcut? {
+    guard let modifier = configuration["modifier"] as? UInt,
+      let keyCodeRawValue = configuration["keyCode"] as? Int,
+      let keyCode = KeyCode(rawValue: keyCodeRawValue)
+    else {
+      return nil
     }
+    return (keyCode, NSEvent.ModifierFlags(rawValue: modifier))
+  }
 
-    override init?(suiteName: String?) {
-        super.init(suiteName: suiteName)
+  override init?(suiteName: String?) {
+    super.init(suiteName: suiteName)
 
-        register(defaults: [
-            ConfigurationName.lastHangulInputMode: "org.youknowone.inputmethod.Gureum.han2",
-            ConfigurationName.lastRomanInputMode: "org.youknowone.inputmethod.Gureum.qwerty",
+    register(defaults: [
+      ConfigurationName.lastHangulInputMode: "org.youknowone.inputmethod.Gureum.han2",
+      ConfigurationName.lastRomanInputMode: "org.youknowone.inputmethod.Gureum.qwerty",
 
-            ConfigurationName.inputModeSearchKey: Configuration.convertShortcutToConfiguration((.return, .option)),
-            ConfigurationName.optionKeyBehavior: 1,
-            ConfigurationName.overridingKeyboardName: "com.apple.keylayout.ABC",
+      ConfigurationName.inputModeSearchKey: Configuration.convertShortcutToConfiguration(
+        (.return, .option)),
+      ConfigurationName.optionKeyBehavior: 1,
+      ConfigurationName.overridingKeyboardName: "com.apple.keylayout.ABC",
 
-            ConfigurationName.romanModeByEscapeKey: false,
-            ConfigurationName.hangulWonCurrencySymbolForBackQuote: true,
-            ConfigurationName.hangulAutoReorder: false,
-            ConfigurationName.hangulNonChoseongCombination: false,
-            ConfigurationName.hangulDeferredSymbolCommit: false,
-            ConfigurationName.hangulForceStrictCombinationRule: false,
-            ConfigurationName.rightToggleKey: kHIDUsage_KeyboardRightAlt,
+      ConfigurationName.romanModeByEscapeKey: false,
+      ConfigurationName.hangulWonCurrencySymbolForBackQuote: true,
+      ConfigurationName.hangulAutoReorder: false,
+      ConfigurationName.hangulNonChoseongCombination: false,
+      ConfigurationName.hangulDeferredSymbolCommit: false,
+      ConfigurationName.hangulForceStrictCombinationRule: false,
+      ConfigurationName.rightToggleKey: kHIDUsage_KeyboardRightAlt,
 
-            ConfigurationName.updateNotification: true,
-            ConfigurationName.updateNotificationExperimental: false,
-        ])
+      ConfigurationName.updateNotification: true,
+      ConfigurationName.updateNotificationExperimental: false,
+    ])
+  }
+
+  convenience init() {
+    self.init(suiteName: Configuration.sharedSuiteName)!
+  }
+
+  public func persistentDomain() -> [String: Any] {
+    return persistentDomain(forName: Configuration.sharedSuiteName) ?? [:]
+  }
+
+  // TODO: code generation
+
+  /// 마지막 한글 입력 모드.
+  public var lastHangulInputMode: String {
+    get {
+      string(forKey: ConfigurationName.lastHangulInputMode)!
     }
-
-    convenience init() {
-        self.init(suiteName: Configuration.sharedSuiteName)!
+    set {
+      set(newValue, forKey: ConfigurationName.lastHangulInputMode)
     }
+  }
 
-    public func persistentDomain() -> [String: Any] {
-        return persistentDomain(forName: Configuration.sharedSuiteName) ?? [:]
+  /// 마지막 로마자 입력 모드.
+  public var lastRomanInputMode: String {
+    get {
+      string(forKey: ConfigurationName.lastRomanInputMode)!
     }
-
-    // TODO: code generation
-
-    /// 마지막 한글 입력 모드.
-    public var lastHangulInputMode: String {
-        get {
-            string(forKey: ConfigurationName.lastHangulInputMode)!
-        }
-        set {
-            set(newValue, forKey: ConfigurationName.lastHangulInputMode)
-        }
+    set {
+      set(newValue, forKey: ConfigurationName.lastRomanInputMode)
     }
+  }
 
-    /// 마지막 로마자 입력 모드.
-    public var lastRomanInputMode: String {
-        get {
-            string(forKey: ConfigurationName.lastRomanInputMode)!
-        }
-        set {
-            set(newValue, forKey: ConfigurationName.lastRomanInputMode)
-        }
+  /// 옵션 키 동작.
+  public var optionKeyBehavior: Int {
+    get {
+      integer(forKey: ConfigurationName.optionKeyBehavior)
     }
+    set {
+      set(newValue, forKey: ConfigurationName.optionKeyBehavior)
+    }
+  }
 
-    /// 옵션 키 동작.
-    public var optionKeyBehavior: Int {
-        get {
-            integer(forKey: ConfigurationName.optionKeyBehavior)
-        }
-        set {
-            set(newValue, forKey: ConfigurationName.optionKeyBehavior)
-        }
+  /// 기본 키보드 레이아웃.
+  public var overridingKeyboardName: String {
+    get {
+      string(forKey: ConfigurationName.overridingKeyboardName)!
     }
+    set {
+      set(newValue, forKey: ConfigurationName.overridingKeyboardName)
+    }
+  }
 
-    /// 기본 키보드 레이아웃.
-    public var overridingKeyboardName: String {
-        get {
-            string(forKey: ConfigurationName.overridingKeyboardName)!
-        }
-        set {
-            set(newValue, forKey: ConfigurationName.overridingKeyboardName)
-        }
+  /// 입력기 바꾸기 단축키.
+  public var inputModeExchangeKey: Shortcut? {
+    get {
+      shortcut(forKey: ConfigurationName.inputModeExchangeKey)
     }
+    set {
+      setShortcut(newValue, forKey: ConfigurationName.inputModeExchangeKey)
+    }
+  }
 
-    /// 입력기 바꾸기 단축키.
-    public var inputModeExchangeKey: Shortcut? {
-        get {
-            shortcut(forKey: ConfigurationName.inputModeExchangeKey)
-        }
-        set {
-            setShortcut(newValue, forKey: ConfigurationName.inputModeExchangeKey)
-        }
+  /// 한자 및 이모지 검색 단축키.
+  public var inputModeSearchKey: Shortcut? {
+    get {
+      shortcut(forKey: ConfigurationName.inputModeSearchKey)
     }
+    set {
+      setShortcut(newValue, forKey: ConfigurationName.inputModeSearchKey)
+    }
+  }
 
-    /// 한자 및 이모지 검색 단축키.
-    public var inputModeSearchKey: Shortcut? {
-        get {
-            shortcut(forKey: ConfigurationName.inputModeSearchKey)
-        }
-        set {
-            setShortcut(newValue, forKey: ConfigurationName.inputModeSearchKey)
-        }
+  /// 로마자로 바꾸기 단축키.
+  public var inputModeEnglishKey: Shortcut? {
+    get {
+      shortcut(forKey: ConfigurationName.inputModeEnglishKey)
     }
+    set {
+      setShortcut(newValue, forKey: ConfigurationName.inputModeEnglishKey)
+    }
+  }
 
-    /// 로마자로 바꾸기 단축키.
-    public var inputModeEnglishKey: Shortcut? {
-        get {
-            shortcut(forKey: ConfigurationName.inputModeEnglishKey)
-        }
-        set {
-            setShortcut(newValue, forKey: ConfigurationName.inputModeEnglishKey)
-        }
+  /// 한글로 바꾸기 단축키.
+  public var inputModeKoreanKey: Shortcut? {
+    get {
+      shortcut(forKey: ConfigurationName.inputModeKoreanKey)
     }
+    set {
+      setShortcut(newValue, forKey: ConfigurationName.inputModeKoreanKey)
+    }
+  }
 
-    /// 한글로 바꾸기 단축키.
-    public var inputModeKoreanKey: Shortcut? {
-        get {
-            shortcut(forKey: ConfigurationName.inputModeKoreanKey)
-        }
-        set {
-            setShortcut(newValue, forKey: ConfigurationName.inputModeKoreanKey)
-        }
+  /// Esc 키로 로마자 자판으로 전환 (vi 모드).
+  public var romanModeByEscapeKey: Bool {
+    get {
+      bool(forKey: ConfigurationName.romanModeByEscapeKey)
     }
+    set {
+      set(newValue, forKey: ConfigurationName.romanModeByEscapeKey)
+    }
+  }
 
-    /// Esc 키로 로마자 자판으로 전환 (vi 모드).
-    public var romanModeByEscapeKey: Bool {
-        get {
-            bool(forKey: ConfigurationName.romanModeByEscapeKey)
-        }
-        set {
-            set(newValue, forKey: ConfigurationName.romanModeByEscapeKey)
-        }
+  /// 한글 입력기일 때 역따옴표(`)로 원화 기호(₩) 입력.
+  public var hangulWonCurrencySymbolForBackQuote: Bool {
+    get {
+      bool(forKey: ConfigurationName.hangulWonCurrencySymbolForBackQuote)
     }
+    set {
+      set(newValue, forKey: ConfigurationName.hangulWonCurrencySymbolForBackQuote)
+    }
+  }
 
-    /// 한글 입력기일 때 역따옴표(`)로 원화 기호(₩) 입력.
-    public var hangulWonCurrencySymbolForBackQuote: Bool {
-        get {
-            bool(forKey: ConfigurationName.hangulWonCurrencySymbolForBackQuote)
-        }
-        set {
-            set(newValue, forKey: ConfigurationName.hangulWonCurrencySymbolForBackQuote)
-        }
+  /// 완성되지 않은 낱자 자동 교정 (모아치기).
+  public var hangulAutoReorder: Bool {
+    get {
+      bool(forKey: ConfigurationName.hangulAutoReorder)
     }
+    set {
+      set(newValue, forKey: ConfigurationName.hangulAutoReorder)
+    }
+  }
 
-    /// 완성되지 않은 낱자 자동 교정 (모아치기).
-    public var hangulAutoReorder: Bool {
-        get {
-            bool(forKey: ConfigurationName.hangulAutoReorder)
-        }
-        set {
-            set(newValue, forKey: ConfigurationName.hangulAutoReorder)
-        }
+  /// 두벌식 초성 조합 중에도 종성 결합 허용 (MS윈도 호환).
+  public var hangulNonChoseongCombination: Bool {
+    get {
+      bool(forKey: ConfigurationName.hangulNonChoseongCombination)
     }
+    set {
+      set(newValue, forKey: ConfigurationName.hangulNonChoseongCombination)
+    }
+  }
 
-    /// 두벌식 초성 조합 중에도 종성 결합 허용 (MS윈도 호환).
-    public var hangulNonChoseongCombination: Bool {
-        get {
-            bool(forKey: ConfigurationName.hangulNonChoseongCombination)
-        }
-        set {
-            set(newValue, forKey: ConfigurationName.hangulNonChoseongCombination)
-        }
+  /// 모든 글자를 조합중인 글자로 취급 (JDK 호환).
+  public var hangulDeferredSymbolCommit: Bool {
+    get {
+      bool(forKey: ConfigurationName.hangulDeferredSymbolCommit)
     }
+    set {
+      set(newValue, forKey: ConfigurationName.hangulDeferredSymbolCommit)
+    }
+  }
 
-    /// 모든 글자를 조합중인 글자로 취급 (JDK 호환).
-    public var hangulDeferredSymbolCommit: Bool {
-        get {
-            bool(forKey: ConfigurationName.hangulDeferredSymbolCommit)
-        }
-        set {
-            set(newValue, forKey: ConfigurationName.hangulDeferredSymbolCommit)
-        }
+  /// 세벌식 정석 강요.
+  public var hangulForceStrictCombinationRule: Bool {
+    get {
+      bool(forKey: ConfigurationName.hangulForceStrictCombinationRule)
     }
+    set {
+      set(newValue, forKey: ConfigurationName.hangulForceStrictCombinationRule)
+    }
+  }
 
-    /// 세벌식 정석 강요.
-    public var hangulForceStrictCombinationRule: Bool {
-        get {
-            bool(forKey: ConfigurationName.hangulForceStrictCombinationRule)
-        }
-        set {
-            set(newValue, forKey: ConfigurationName.hangulForceStrictCombinationRule)
-        }
+  /// 우측 키로 언어 전환
+  public var rightToggleKey: Int {
+    get {
+      integer(forKey: ConfigurationName.rightToggleKey)
     }
+    set {
+      set(newValue, forKey: ConfigurationName.rightToggleKey)
+    }
+  }
 
-    /// 우측 키로 언어 전환
-    public var rightToggleKey: Int {
-        get {
-            integer(forKey: ConfigurationName.rightToggleKey)
-        }
-        set {
-            set(newValue, forKey: ConfigurationName.rightToggleKey)
-        }
+  /// 업데이트 알림 받기
+  public var updateNotification: Bool {
+    get {
+      bool(forKey: ConfigurationName.updateNotification)
     }
+    set {
+      set(newValue, forKey: ConfigurationName.updateNotification)
+    }
+  }
 
-    /// 업데이트 알림 받기
-    public var updateNotification: Bool {
-        get {
-            bool(forKey: ConfigurationName.updateNotification)
-        }
-        set {
-            set(newValue, forKey: ConfigurationName.updateNotification)
-        }
+  /// 실험버전 업데이트 알림 받기
+  public var updateNotificationExperimental: Bool {
+    get {
+      if Bundle.main.isExperimental {
+        return true
+      } else {
+        return bool(forKey: ConfigurationName.updateNotificationExperimental)
+      }
     }
+    set {
+      assert(!Bundle.main.isExperimental)
+      set(newValue, forKey: ConfigurationName.updateNotificationExperimental)
+    }
+  }
 
-    /// 실험버전 업데이트 알림 받기
-    public var updateNotificationExperimental: Bool {
-        get {
-            if Bundle.main.isExperimental {
-                return true
-            } else {
-                return bool(forKey: ConfigurationName.updateNotificationExperimental)
-            }
-        }
-        set {
-            assert(!Bundle.main.isExperimental)
-            set(newValue, forKey: ConfigurationName.updateNotificationExperimental)
-        }
+  public var updateMode: UpdateMode? {
+    switch (updateNotification, updateNotificationExperimental) {
+    case (false, _):
+      return nil
+    case (true, false):
+      return .stable
+    case (true, true):
+      return .experimental
     }
-
-    public var updateMode: UpdateMode? {
-        switch (updateNotification, updateNotificationExperimental) {
-        case (false, _):
-            return nil
-        case (true, false):
-            return .Stable
-        case (true, true):
-            return .Experimental
-        }
-    }
+  }
 }
 
-private extension Configuration {
-    func shortcut(forKey key: String) -> Shortcut? {
-        guard let value = dictionary(forKey: key) else { return nil }
-        return Configuration.convertConfigurationToShortcut(value)
-    }
+extension Configuration {
+  fileprivate func shortcut(forKey key: String) -> Shortcut? {
+    guard let value = dictionary(forKey: key) else { return nil }
+    return Configuration.convertConfigurationToShortcut(value)
+  }
 
-    func setShortcut(_ newValue: Shortcut?, forKey key: String) {
-        set(Configuration.convertShortcutToConfiguration(newValue), forKey: key)
-    }
+  fileprivate func setShortcut(_ newValue: Shortcut?, forKey key: String) {
+    set(Configuration.convertShortcutToConfiguration(newValue), forKey: key)
+  }
 }

--- a/OSXCore/Debug.swift
+++ b/OSXCore/Debug.swift
@@ -9,15 +9,15 @@
 import Foundation
 
 #if DEBUG
-    func dlog(_ flag: Bool, _ format: String, _ args: CVarArg...) {
-        guard flag else {
-            return
-        }
-        NSLogv(format, getVaList(args))
+  func dlog(_ flag: Bool, _ format: String, _ args: CVarArg...) {
+    guard flag else {
+      return
     }
+    NSLogv(format, getVaList(args))
+  }
 
 #else
-    func dlog(_: CVarArg...) {
-        // do nothing in release mode
-    }
+  func dlog(_: CVarArg...) {
+    // do nothing in release mode
+  }
 #endif

--- a/OSXCore/GureumApplicationDelegate.swift
+++ b/OSXCore/GureumApplicationDelegate.swift
@@ -9,6 +9,6 @@
 import Cocoa
 
 @objc public protocol GureumApplicationDelegate: NSObjectProtocol {
-    //! @brief  언어 설정에 추가될 메뉴
-    @objc var menu: NSMenu! { get }
+  //! @brief  언어 설정에 추가될 메뉴
+  @objc var menu: NSMenu! { get }
 }

--- a/OSXCore/GureumComposer.swift
+++ b/OSXCore/GureumComposer.swift
@@ -16,38 +16,38 @@ import Foundation
 ///
 /// 각 케이스의 원시 값은 그에 대응하는 input method의 번들 식별자를 나타낸다.
 enum GureumInputSource: String {
-    /// 로마자 시스템 자판.
-    case system = "org.youknowone.inputmethod.Gureum.system"
-    /// 로마자 쿼티 자판.
-    case qwerty = "org.youknowone.inputmethod.Gureum.qwerty"
-    /// 로마자 드보락 자판.
-    case dvorak = "org.youknowone.inputmethod.Gureum.dvorak"
-    /// 로마자 콜맥 자판.
-    case colemak = "org.youknowone.inputmethod.Gureum.colemak"
-    /// 한글 두벌식 자판.
-    case han2 = "org.youknowone.inputmethod.Gureum.han2"
-    /// 한글 두벌식 옛글 자판.
-    case han2Classic = "org.youknowone.inputmethod.Gureum.han2classic"
-    /// 한글 세벌식 최종 자판.
-    case han3Final = "org.youknowone.inputmethod.Gureum.han3final"
-    /// 한글 세벌식 390 자판.
-    case han390 = "org.youknowone.inputmethod.Gureum.han390"
-    /// 한글 세벌식 순아래 자판.
-    case han3NoShift = "org.youknowone.inputmethod.Gureum.han3noshift"
-    /// 한글 세벌식 옛글 자판.
-    case han3Classic = "org.youknowone.inputmethod.Gureum.han3classic"
-    /// 한글 세벌식 두벌식 배치 자판.
-    case han3Layout2 = "org.youknowone.inputmethod.Gureum.han3layout2"
-    /// 한글 안마태 자판.
-    case hanAhnmatae = "org.youknowone.inputmethod.Gureum.hanahnmatae"
-    /// 한글 로마자 자판.
-    case hanRoman = "org.youknowone.inputmethod.Gureum.hanroman"
-    /// 한글 세벌식 최종 순아래 자판.
-    case han3FinalNoShift = "org.youknowone.inputmethod.Gureum.han3finalnoshift"
-    /// 한글 세벌식 2011 자판.
-    case han3_2011 = "org.youknowone.inputmethod.Gureum.han3-2011"
-    /// 한글 세벌식 2012 자판.
-    case han3_2012 = "org.youknowone.inputmethod.Gureum.han3-2012"
+  /// 로마자 시스템 자판.
+  case system = "org.youknowone.inputmethod.Gureum.system"
+  /// 로마자 쿼티 자판.
+  case qwerty = "org.youknowone.inputmethod.Gureum.qwerty"
+  /// 로마자 드보락 자판.
+  case dvorak = "org.youknowone.inputmethod.Gureum.dvorak"
+  /// 로마자 콜맥 자판.
+  case colemak = "org.youknowone.inputmethod.Gureum.colemak"
+  /// 한글 두벌식 자판.
+  case han2 = "org.youknowone.inputmethod.Gureum.han2"
+  /// 한글 두벌식 옛글 자판.
+  case han2Classic = "org.youknowone.inputmethod.Gureum.han2classic"
+  /// 한글 세벌식 최종 자판.
+  case han3Final = "org.youknowone.inputmethod.Gureum.han3final"
+  /// 한글 세벌식 390 자판.
+  case han390 = "org.youknowone.inputmethod.Gureum.han390"
+  /// 한글 세벌식 순아래 자판.
+  case han3NoShift = "org.youknowone.inputmethod.Gureum.han3noshift"
+  /// 한글 세벌식 옛글 자판.
+  case han3Classic = "org.youknowone.inputmethod.Gureum.han3classic"
+  /// 한글 세벌식 두벌식 배치 자판.
+  case han3Layout2 = "org.youknowone.inputmethod.Gureum.han3layout2"
+  /// 한글 안마태 자판.
+  case hanAhnmatae = "org.youknowone.inputmethod.Gureum.hanahnmatae"
+  /// 한글 로마자 자판.
+  case hanRoman = "org.youknowone.inputmethod.Gureum.hanroman"
+  /// 한글 세벌식 최종 순아래 자판.
+  case han3FinalNoShift = "org.youknowone.inputmethod.Gureum.han3finalnoshift"
+  /// 한글 세벌식 2011 자판.
+  case han32011 = "org.youknowone.inputmethod.Gureum.han3-2011"
+  /// 한글 세벌식 2012 자판.
+  case han32012 = "org.youknowone.inputmethod.Gureum.han3-2012"
 }
 
 // MARK: - GureumComposer 클래스
@@ -56,284 +56,300 @@ enum GureumInputSource: String {
 ///
 /// 입력 모드에 따라 `libhangul`을 이용하여 문자를 합성해 준다.
 final class GureumComposer: Composer {
-    // MARK: 합성기 테이블
+  // MARK: 합성기 테이블
 
-    /// 한글 합성기.
-    let hangulComposer = HangulComposer(type: .han2)
-    /// 한글 합성기에 의존하여 문자를 검색하고 입력하는 합성기.
-    ///
-    /// 한자 및 이모지  합성기
-    let searchComposer = SearchComposer()
+  /// 한글 합성기.
+  let hangulComposer = HangulComposer(type: .han2)
+  /// 한글 합성기에 의존하여 문자를 검색하고 입력하는 합성기.
+  ///
+  /// 한자 및 이모지  합성기
+  let searchComposer = SearchComposer()
 
-    /// 로마자 시스템 합성기.
-    let systemRomanComposer = RomanComposer(type: .system)
-    /// 로마자 쿼티 합성기.
-    let qwertyComposer = RomanComposer(type: .qwerty)
-    /// 로마자 드보락 합성기.
-    let dvorakComposer = RomanComposer(type: .dvorak)
-    /// 로마자 콜맥 합성기.
-    let colemakComposer = RomanComposer(type: .colemak)
+  /// 로마자 시스템 합성기.
+  let systemRomanComposer = RomanComposer(type: .system)
+  /// 로마자 쿼티 합성기.
+  let qwertyComposer = RomanComposer(type: .qwerty)
+  /// 로마자 드보락 합성기.
+  let dvorakComposer = RomanComposer(type: .dvorak)
+  /// 로마자 콜맥 합성기.
+  let colemakComposer = RomanComposer(type: .colemak)
 
-    private var _inputMode: String = ""
-    private var _commitStrings: [String] = []
+  private var _inputMode: String = ""
+  private var _commitStrings: [String] = []
 
-    /// 실제 사용되는 로마자 합성기.
-    var romanComposer: RomanComposer
+  /// 실제 사용되는 로마자 합성기.
+  var romanComposer: RomanComposer
 
-    init() {
-        romanComposer = systemRomanComposer
-        inputMode = Configuration.shared.lastRomanInputMode
-        delegate = romanComposer
-    }
+  init() {
+    romanComposer = systemRomanComposer
+    inputMode = Configuration.shared.lastRomanInputMode
+    delegate = romanComposer
+  }
 
-    // MARK: Composer 프로토콜 구현
+  // MARK: Composer 프로토콜 구현
 
-    var delegate: Composer!
+  var delegate: Composer!
 
-    var commitString: String {
-        return _commitStrings.joined() + delegate.commitString
-    }
+  var commitString: String {
+    return _commitStrings.joined() + delegate.commitString
+  }
 
-    func clear() {
-        hangulComposer.clear()
-        romanComposer.clear()
-        searchComposer.clear()
-    }
+  func clear() {
+    hangulComposer.clear()
+    romanComposer.clear()
+    searchComposer.clear()
+  }
 
-    func dequeueCommitString() -> String {
-        let r = commitString
-        delegate.dequeueCommitString()
-        _commitStrings.removeAll()
-        return r
-    }
+  func dequeueCommitString() -> String {
+    let r = commitString
+    delegate.dequeueCommitString()
+    _commitStrings.removeAll()
+    return r
+  }
 
-    func input(text string: String?, key keyCode: KeyCode, modifiers flags: NSEvent.ModifierFlags, client sender: IMKTextInput & IMKUnicodeTextInput) -> InputResult {
-        if flags.contains(.option) {
-            if delegate is HangulComposer {
-                // 옵션 키 변환 처리
-                let configuration = Configuration.shared
-                dlog(DEBUG_INPUT_RECEIVER, "option key: %ld", configuration.optionKeyBehavior)
-                switch configuration.optionKeyBehavior {
-                case 0:
-                    // default
-                    dlog(DEBUG_INPUT_RECEIVER, " ** ESCAPE from option-key default behavior")
-                    return InputResult(processed: false, action: .commit)
-                case 1:
-                    // roman
-                    let mappingComposer = romanComposer !== systemRomanComposer ? romanComposer : qwertyComposer
-                    let character = mappingComposer.map(text: string, key: keyCode, modifiers: flags)
-                    dlog(DEBUG_INPUT_RECEIVER, " ** ESCAPE from option-key roman mapping `\(string ?? " ")` -> `\(character ?? " ")` by \(keyCode) \(flags) \(String(describing: romanComposer))")
-                    guard let character = character else {
-                        return InputResult(processed: false, action: .commit)
-                    }
+  func input(
+    text string: String?, key keyCode: KeyCode, modifiers flags: NSEvent.ModifierFlags,
+    client sender: IMKTextInput & IMKUnicodeTextInput
+  ) -> InputResult {
+    if flags.contains(.option) {
+      if delegate is HangulComposer {
+        // 옵션 키 변환 처리
+        let configuration = Configuration.shared
+        dlog(debugInputReceiver, "option key: %ld", configuration.optionKeyBehavior)
+        switch configuration.optionKeyBehavior {
+        case 0:
+          // default
+          dlog(debugInputReceiver, " ** ESCAPE from option-key default behavior")
+          return InputResult(processed: false, action: .commit)
+        case 1:
+          // roman
+          let mappingComposer =
+            romanComposer !== systemRomanComposer ? romanComposer : qwertyComposer
+          let character = mappingComposer.map(text: string, key: keyCode, modifiers: flags)
+          dlog(
+            debugInputReceiver,
+            " ** ESCAPE from option-key roman mapping `\(string ?? " ")` -> `\(character ?? " ")` by \(keyCode) \(flags) \(String(describing: romanComposer))"
+          )
+          guard let character = character else {
+            return InputResult(processed: false, action: .commit)
+          }
 
-                    cancelAndCommit()
-                    enqueueCommitString("\(character)")
-                    return InputResult(processed: true, action: .commit)
-                default:
-                    assertionFailure()
-                }
-            } else {
-                return .notProcessed
-            }
+          cancelAndCommit()
+          enqueueCommitString("\(character)")
+          return InputResult(processed: true, action: .commit)
+        default:
+          assertionFailure()
         }
-        return delegate.input(text: string, key: keyCode, modifiers: flags, client: sender)
+      } else {
+        return .notProcessed
+      }
     }
+    return delegate.input(text: string, key: keyCode, modifiers: flags, client: sender)
+  }
 }
 
 extension GureumComposer {
-    var inputMode: String {
-        get {
-            return _inputMode
-        }
-        set {
-            guard inputMode != newValue else { return }
-
-            if let romanComposerType = RomanComposer.ComposerType(inputMode: newValue) {
-                romanComposer = romanComposer(by: romanComposerType)
-                delegate = romanComposer
-                Configuration.shared.lastRomanInputMode = newValue
-            } else {
-                guard let keyboardIdentifier = GureumInputSource(rawValue: newValue)?.keyboardIdentifier else {
-                    #if DEBUG
-                        assertionFailure()
-                    #endif
-                    return
-                }
-                delegate = hangulComposer
-                // 단축키 지원을 위해 마지막 자판을 기억
-                hangulComposer.setKeyboard(identifier: keyboardIdentifier)
-                Configuration.shared.lastHangulInputMode = newValue
-            }
-
-            _inputMode = newValue
-        }
+  var inputMode: String {
+    get {
+      return _inputMode
     }
+    set {
+      guard inputMode != newValue else { return }
 
-    func cancelAndCommit() {
-        delegate.cancelComposition()
-        enqueueCommitString(delegate.dequeueCommitString())
-    }
-
-    func changeLayout(_ layout: ChangeLayout, client sender: Any) -> InputResult {
-        var layout = layout
-        if layout == .toggle {
-            if delegate is RomanComposer {
-                layout = .hangul
-            } else if delegate is HangulComposer {
-                layout = .roman
-            } else {
-                return .notProcessed
-            }
-        }
-
-        if delegate is SearchComposer {
-            searchComposer.cancelSearch()
-        }
-        switch layout {
-        case .hangul, .roman:
-            // 한영전환을 위해 현재 입력 중인 문자 합성 취소
-            let config = Configuration.shared
-            cancelAndCommit()
-            inputMode = layout == .hangul ? config.lastHangulInputMode : config.lastRomanInputMode
-            return InputResult(processed: true, action: .layout(inputMode))
-        case .search:
-            // 한글 입력 상태에서 한자 및 이모티콘 입력기로 전환
-            if delegate is HangulComposer {
-                // 현재 조합 중 여부에 따라 한자 모드 여부를 결정
-                let isComposing = !hangulComposer.composedString.isEmpty
-                searchComposer.showsCandidateWindow = !isComposing
-                searchComposer.delegate = delegate
-            } else if delegate is RomanComposer {
-                searchComposer.delegate = delegate
-            } else {
-                return .notProcessed
-            }
-            delegate = searchComposer
-            delegate.composerSelected()
-            searchComposer.update(client: sender as! IMKTextInput)
-            return .processed
-        default:
+      if let romanComposerType = RomanComposer.ComposerType(inputMode: newValue) {
+        romanComposer = romanComposer(by: romanComposerType)
+        delegate = romanComposer
+        Configuration.shared.lastRomanInputMode = newValue
+      } else {
+        guard let keyboardIdentifier = GureumInputSource(rawValue: newValue)?.keyboardIdentifier
+        else {
+          #if DEBUG
             assertionFailure()
-            return .notProcessed
+          #endif
+          return
         }
+        delegate = hangulComposer
+        // 단축키 지원을 위해 마지막 자판을 기억
+        hangulComposer.setKeyboard(identifier: keyboardIdentifier)
+        Configuration.shared.lastHangulInputMode = newValue
+      }
+
+      _inputMode = newValue
+    }
+  }
+
+  func cancelAndCommit() {
+    delegate.cancelComposition()
+    enqueueCommitString(delegate.dequeueCommitString())
+  }
+
+  func changeLayout(_ layout: ChangeLayout, client sender: Any) -> InputResult {
+    var layout = layout
+    if layout == .toggle {
+      if delegate is RomanComposer {
+        layout = .hangul
+      } else if delegate is HangulComposer {
+        layout = .roman
+      } else {
+        return .notProcessed
+      }
     }
 
-    func filterCommand(keyCode: KeyCode,
-                       modifiers flags: NSEvent.ModifierFlags,
-                       client _: Any) -> InputEvent?
+    if delegate is SearchComposer {
+      searchComposer.cancelSearch()
+    }
+    switch layout {
+    case .hangul, .roman:
+      // 한영전환을 위해 현재 입력 중인 문자 합성 취소
+      let config = Configuration.shared
+      cancelAndCommit()
+      inputMode = layout == .hangul ? config.lastHangulInputMode : config.lastRomanInputMode
+      return InputResult(processed: true, action: .layout(inputMode))
+    case .search:
+      // 한글 입력 상태에서 한자 및 이모티콘 입력기로 전환
+      if delegate is HangulComposer {
+        // 현재 조합 중 여부에 따라 한자 모드 여부를 결정
+        let isComposing = !hangulComposer.composedString.isEmpty
+        searchComposer.showsCandidateWindow = !isComposing
+        searchComposer.delegate = delegate
+      } else if delegate is RomanComposer {
+        searchComposer.delegate = delegate
+      } else {
+        return .notProcessed
+      }
+      delegate = searchComposer
+      delegate.composerSelected()
+      searchComposer.update(client: sender as! IMKTextInput)
+      return .processed
+    default:
+      assertionFailure()
+      return .notProcessed
+    }
+  }
+
+  func filterCommand(
+    keyCode: KeyCode,
+    modifiers flags: NSEvent.ModifierFlags,
+    client _: Any
+  ) -> InputEvent? {
+    let configuration = Configuration.shared
+    let inputModifier =
+      flags
+      .intersection(.deviceIndependentFlagsMask)
+      .intersection(NSEvent.ModifierFlags(rawValue: ~NSEvent.ModifierFlags.capsLock.rawValue))
+
+    // Handle SpecialKeyCode first
+    let inputKey = (keyCode, inputModifier)
+    if let shortcutKey = configuration.inputModeExchangeKey, shortcutKey == inputKey {
+      return .changeLayout(.toggle, true)
+    }
+    if delegate is HangulComposer, let shortcutKey = configuration.inputModeEnglishKey,
+      shortcutKey == inputKey
     {
-        let configuration = Configuration.shared
-        let inputModifier = flags
-            .intersection(.deviceIndependentFlagsMask)
-            .intersection(NSEvent.ModifierFlags(rawValue: ~NSEvent.ModifierFlags.capsLock.rawValue))
-
-        // Handle SpecialKeyCode first
-        let inputKey = (keyCode, inputModifier)
-        if let shortcutKey = configuration.inputModeExchangeKey, shortcutKey == inputKey {
-            return .changeLayout(.toggle, true)
+      return .changeLayout(.roman, true)
+    }
+    if delegate is RomanComposer, let shortcutKey = configuration.inputModeKoreanKey,
+      shortcutKey == inputKey
+    {
+      return .changeLayout(.hangul, true)
+    }
+    if let shortcutKey = configuration.inputModeSearchKey, shortcutKey == inputKey {
+      // 이미 연속 입력모드라면 한자 단축키로 탈출
+      if let searchComposer = delegate as? SearchComposer {
+        searchComposer.exitComposer()
+        if searchComposer.delegate is HangulComposer {
+          return .changeLayout(.hangul, true)
+        } else if searchComposer.delegate is RomanComposer {
+          return .changeLayout(.roman, true)
         }
-        if delegate is HangulComposer, let shortcutKey = configuration.inputModeEnglishKey, shortcutKey == inputKey {
-            return .changeLayout(.roman, true)
-        }
-        if delegate is RomanComposer, let shortcutKey = configuration.inputModeKoreanKey, shortcutKey == inputKey {
-            return .changeLayout(.hangul, true)
-        }
-        if let shortcutKey = configuration.inputModeSearchKey, shortcutKey == inputKey {
-            // 이미 연속 입력모드라면 한자 단축키로 탈출
-            if let searchComposer = delegate as? SearchComposer {
-                searchComposer.exitComposer()
-                if searchComposer.delegate is HangulComposer {
-                    return .changeLayout(.hangul, true)
-                } else if searchComposer.delegate is RomanComposer {
-                    return .changeLayout(.roman, true)
-                }
-            }
-            return .changeLayout(.search, true)
-        }
-
-        if let searchComposer = delegate as? SearchComposer {
-            if searchComposer.delegate is HangulComposer, !searchComposer.showsCandidateWindow, searchComposer.composedString.isEmpty, searchComposer.commitString.isEmpty {
-                // 한자 입력이 완료되었고 한자 모드도 아님
-                delegate = hangulComposer
-                searchComposer.delegate = nil
-            } else if searchComposer.delegate is RomanComposer {
-                if !searchComposer.showsCandidateWindow {
-                    searchComposer.showsCandidateWindow = true
-                    delegate = romanComposer
-                    searchComposer.delegate = nil
-                }
-            }
-        }
-
-        if delegate is HangulComposer {
-            // Vi-mode: esc로 로마자 키보드로 전환
-            if Configuration.shared.romanModeByEscapeKey {
-                if keyCode == .escape || inputKey == (.ansiLeftBracket, .control) {
-                    return .changeLayout(.roman, false)
-                }
-            }
-        }
-
-        return nil
+      }
+      return .changeLayout(.search, true)
     }
 
-    private func enqueueCommitString(_ string: String) {
-        _commitStrings.append(string)
+    if let searchComposer = delegate as? SearchComposer {
+      if searchComposer.delegate is HangulComposer, !searchComposer.showsCandidateWindow,
+        searchComposer.composedString.isEmpty, searchComposer.commitString.isEmpty
+      {
+        // 한자 입력이 완료되었고 한자 모드도 아님
+        delegate = hangulComposer
+        searchComposer.delegate = nil
+      } else if searchComposer.delegate is RomanComposer {
+        if !searchComposer.showsCandidateWindow {
+          searchComposer.showsCandidateWindow = true
+          delegate = romanComposer
+          searchComposer.delegate = nil
+        }
+      }
     }
 
-    func romanComposer(by romanComposerType: RomanComposer.ComposerType) -> RomanComposer {
-        switch romanComposerType {
-        case .system:
-            return systemRomanComposer
-        case .qwerty:
-            return qwertyComposer
-        case .dvorak:
-            return dvorakComposer
-        case .colemak:
-            return colemakComposer
+    if delegate is HangulComposer {
+      // Vi-mode: esc로 로마자 키보드로 전환
+      if Configuration.shared.romanModeByEscapeKey {
+        if keyCode == .escape || inputKey == (.ansiLeftBracket, .control) {
+          return .changeLayout(.roman, false)
         }
+      }
     }
+
+    return nil
+  }
+
+  private func enqueueCommitString(_ string: String) {
+    _commitStrings.append(string)
+  }
+
+  func romanComposer(by romanComposerType: RomanComposer.ComposerType) -> RomanComposer {
+    switch romanComposerType {
+    case .system:
+      return systemRomanComposer
+    case .qwerty:
+      return qwertyComposer
+    case .dvorak:
+      return dvorakComposer
+    case .colemak:
+      return colemakComposer
+    }
+  }
 }
 
 // MARK: - GureumInputSource 열거형 확장
 
 extension GureumInputSource {
-    /// 키보드 식별자.
-    var keyboardIdentifier: String {
-        switch self {
-        case .system:
-            return "system"
-        case .qwerty:
-            return "qwerty"
-        case .dvorak:
-            return "dvorak"
-        case .colemak:
-            return "colemak"
-        case .han2:
-            return "2-full"
-        case .han2Classic:
-            return "2y-full"
-        case .han3Final:
-            return "3f"
-        case .han390:
-            return "39"
-        case .han3NoShift:
-            return "3s"
-        case .han3Classic:
-            return "3y"
-        case .han3Layout2:
-            return "32"
-        case .hanAhnmatae:
-            return "ahn"
-        case .hanRoman:
-            return "ro"
-        case .han3FinalNoShift:
-            return "3gs"
-        case .han3_2011:
-            return "3-2011"
-        case .han3_2012:
-            return "3-2012"
-        }
+  /// 키보드 식별자.
+  var keyboardIdentifier: String {
+    switch self {
+    case .system:
+      return "system"
+    case .qwerty:
+      return "qwerty"
+    case .dvorak:
+      return "dvorak"
+    case .colemak:
+      return "colemak"
+    case .han2:
+      return "2-full"
+    case .han2Classic:
+      return "2y-full"
+    case .han3Final:
+      return "3f"
+    case .han390:
+      return "39"
+    case .han3NoShift:
+      return "3s"
+    case .han3Classic:
+      return "3y"
+    case .han3Layout2:
+      return "32"
+    case .hanAhnmatae:
+      return "ahn"
+    case .hanRoman:
+      return "ro"
+    case .han3FinalNoShift:
+      return "3gs"
+    case .han32011:
+      return "3-2011"
+    case .han32012:
+      return "3-2012"
     }
+  }
 }

--- a/OSXCore/HangulComposer.swift
+++ b/OSXCore/HangulComposer.swift
@@ -11,46 +11,55 @@ import Cocoa
 import Foundation
 import Hangul
 
-let CHO_FILLER = 0x115F
-let JUNG_FILLER = 0x1160
-let DEBUG_HANGULCOMPOSER = false
+let choFiller = 0x115F
+let jungFiller = 0x1160
+let debugHangulComposer = false
 
 private let table: [HGUCSChar: HGUCSChar] = [
-    // {'ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ', 'ㅢ', 'ㅣ'}
-    0x1161: 0x314F, 0x1162: 0x3150, 0x1163: 0x3151, 0x1164: 0x3152, 0x1165: 0x3153, 0x1166: 0x3154, 0x1167: 0x3155, 0x1168: 0x3156, 0x1169: 0x3157, 0x116A: 0x3158, 0x116B: 0x3159, 0x116C: 0x315A, 0x116D: 0x315B, 0x116E: 0x315C, 0x116F: 0x315D, 0x1170: 0x315E, 0x1171: 0x315F, 0x1172: 0x3160, 0x1173: 0x3161, 0x1174: 0x3162, 0x1175: 0x3163,
-    // {JONGSUNG ' ', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ', 'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ', 'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'}
-    0x0000: 0x0000, 0x11A8: 0x3131, 0x11A9: 0x3132, 0x11AA: 0x3133, 0x11AB: 0x3134, 0x11AC: 0x3135, 0x11AD: 0x3136, 0x11AE: 0x3137, 0x11AF: 0x3139, 0x11B0: 0x313A, 0x11B1: 0x313B, 0x11B2: 0x313C, 0x11B3: 0x313D, 0x11B4: 0x313E, 0x11B5: 0x313F, 0x11B6: 0x3140, 0x11B7: 0x3141, 0x11B8: 0x3142, 0x11B9: 0x3144, 0x11BA: 0x3145, 0x11BB: 0x3146, 0x11BC: 0x3147, 0x11BD: 0x3148, 0x11BE: 0x314A, 0x11BF: 0x314B, 0x11C0: 0x314C, 0x11C1: 0x314D, 0x11C2: 0x314E,
+  // {'ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ', 'ㅢ', 'ㅣ'}
+  0x1161: 0x314F, 0x1162: 0x3150, 0x1163: 0x3151, 0x1164: 0x3152, 0x1165: 0x3153, 0x1166: 0x3154,
+  0x1167: 0x3155, 0x1168: 0x3156, 0x1169: 0x3157, 0x116A: 0x3158, 0x116B: 0x3159, 0x116C: 0x315A,
+  0x116D: 0x315B, 0x116E: 0x315C, 0x116F: 0x315D, 0x1170: 0x315E, 0x1171: 0x315F, 0x1172: 0x3160,
+  0x1173: 0x3161, 0x1174: 0x3162, 0x1175: 0x3163,
+  // {JONGSUNG ' ', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ', 'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ', 'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'}
+  0x0000: 0x0000, 0x11A8: 0x3131, 0x11A9: 0x3132, 0x11AA: 0x3133, 0x11AB: 0x3134, 0x11AC: 0x3135,
+  0x11AD: 0x3136, 0x11AE: 0x3137, 0x11AF: 0x3139, 0x11B0: 0x313A, 0x11B1: 0x313B, 0x11B2: 0x313C,
+  0x11B3: 0x313D, 0x11B4: 0x313E, 0x11B5: 0x313F, 0x11B6: 0x3140, 0x11B7: 0x3141, 0x11B8: 0x3142,
+  0x11B9: 0x3144, 0x11BA: 0x3145, 0x11BB: 0x3146, 0x11BC: 0x3147, 0x11BD: 0x3148, 0x11BE: 0x314A,
+  0x11BF: 0x314B, 0x11C0: 0x314C, 0x11C1: 0x314D, 0x11C2: 0x314E,
 ]
 
 /// 한글호환 자모 유니코드로 바꿔주는 함수.
 func convertUnicode(_ ucsString: UnsafePointer<HGUCSChar>) -> [HGUCSChar] {
-    var newUcsString = [HGUCSChar]()
-    var skipped = 0
-    while ucsString[skipped + newUcsString.count] != UInt32(0) {
-        let index = skipped + newUcsString.count
-        let newChr: HGUCSChar
-        if let chr = table[ucsString[index]] {
-            newChr = chr
-        } else {
-            newChr = ucsString[index]
-        }
-        if newChr == CHO_FILLER || newChr == JUNG_FILLER {
-            skipped += 1
-        } else {
-            newUcsString.append(newChr)
-        }
+  var newUcsString = [HGUCSChar]()
+  var skipped = 0
+  while ucsString[skipped + newUcsString.count] != UInt32(0) {
+    let index = skipped + newUcsString.count
+    let newChr: HGUCSChar
+    if let chr = table[ucsString[index]] {
+      newChr = chr
+    } else {
+      newChr = ucsString[index]
     }
-    newUcsString.append(0)
-    return newUcsString
+    if newChr == choFiller || newChr == jungFiller {
+      skipped += 1
+    } else {
+      newUcsString.append(newChr)
+    }
+  }
+  newUcsString.append(0)
+  return newUcsString
 }
 
 func representableString(ucsString: UnsafePointer<HGUCSChar>) -> String {
-    let isCombinating = !HGCharacterIsChoseong(ucsString[0]) || ucsString[0] == CHO_FILLER || ucsString[1] == JUNG_FILLER
-    if isCombinating {
-        return NSString(ucsString: convertUnicode(ucsString)) as String
-    }
-    // 옛한글은 그대로
-    return NSString(ucsString: ucsString) as String
+  let isCombinating =
+    !HGCharacterIsChoseong(ucsString[0]) || ucsString[0] == choFiller
+    || ucsString[1] == jungFiller
+  if isCombinating {
+    return NSString(ucsString: convertUnicode(ucsString)) as String
+  }
+  // 옛한글은 그대로
+  return NSString(ucsString: ucsString) as String
 }
 
 // MARK: - HangulComposer 클래스
@@ -61,226 +70,243 @@ func representableString(ucsString: UnsafePointer<HGUCSChar>) -> String {
 ///
 /// `HGInputContext` 클래스를 참고한다.
 final class HangulComposer: NSObject, Composer {
-    /// 한글 합성기의 종류를 정의한 열거형.
-    ///
-    /// 각 케이스의 원시 값은 그에 대응하는 키보드 식별자를 나타낸다.
-    enum ComposerType: String {
-        /// 두벌식 자판.
-        case han2 = "2-full"
-        /// 두벌식 옛글 자판.
-        case han2Classic = "2y-full"
-        /// 세벌식 최종 자판.
-        case han3Final = "3f"
-        /// 세벌식 390 자판.
-        case han390 = "39"
-        /// 세벌식 순아래 자판.
-        case han3NoShift = "3s"
-        /// 세벌식 옛글 자판.
-        case han3Classic = "3y"
-        /// 세벌식 두벌식 배치 자판.
-        case han3Layout2 = "32"
-        /// 세벌식 로마자 자판.
-        case hanRoman = "ro"
-        /// 안마태 자판.
-        case hanAhnmatae = "ahn"
-        /// 세벌식 최종 순아래 자판.
-        case han3FinalNoShift = "3gs"
-        /// 세벌식 2011 자판.
-        case han3_2011 = "3-2011"
-        /// 세벌식 2012 자판.
-        case han3_2012 = "3-2012"
+  /// 한글 합성기의 종류를 정의한 열거형.
+  ///
+  /// 각 케이스의 원시 값은 그에 대응하는 키보드 식별자를 나타낸다.
+  enum ComposerType: String {
+    /// 두벌식 자판.
+    case han2 = "2-full"
+    /// 두벌식 옛글 자판.
+    case han2Classic = "2y-full"
+    /// 세벌식 최종 자판.
+    case han3Final = "3f"
+    /// 세벌식 390 자판.
+    case han390 = "39"
+    /// 세벌식 순아래 자판.
+    case han3NoShift = "3s"
+    /// 세벌식 옛글 자판.
+    case han3Classic = "3y"
+    /// 세벌식 두벌식 배치 자판.
+    case han3Layout2 = "32"
+    /// 세벌식 로마자 자판.
+    case hanRoman = "ro"
+    /// 안마태 자판.
+    case hanAhnmatae = "ahn"
+    /// 세벌식 최종 순아래 자판.
+    case han3FinalNoShift = "3gs"
+    /// 세벌식 2011 자판.
+    case han32011 = "3-2011"
+    /// 세벌식 2012 자판.
+    case han32012 = "3-2012"
+  }
+
+  /// 합성을 완료한 문자열.
+  private var _commitString: String
+  /// 합성 중인 문자열. 현재는 JDK 호환 모드에만 사용된다.
+  private var _composedString: String
+
+  let inputContext: HGInputContext
+  let configuration = Configuration.shared
+
+  init(type: HangulComposer.ComposerType) {
+    _commitString = ""
+    _composedString = ""
+    let keyboardIdentifier = type.rawValue
+    let inputContext = HGInputContext(keyboardIdentifier: keyboardIdentifier)!
+    self.inputContext = inputContext
+    self.inputContext.setOption(
+      HANGUL_IC_OPTION_AUTO_REORDER, value: configuration.hangulAutoReorder)
+    self.inputContext.setOption(
+      HANGUL_IC_OPTION_NON_CHOSEONG_COMBI, value: configuration.hangulNonChoseongCombination)
+    super.init()
+    configuration.addObserver(
+      self, forKeyPath: ConfigurationName.hangulAutoReorder, options: .new, context: nil)
+    configuration.addObserver(
+      self, forKeyPath: ConfigurationName.hangulNonChoseongCombination, options: .new, context: nil)
+    configuration.addObserver(
+      self, forKeyPath: ConfigurationName.hangulForceStrictCombinationRule, options: .new,
+      context: nil)
+  }
+
+  override func observeValue(
+    forKeyPath keyPath: String?, of _: Any?, change _: [NSKeyValueChangeKey: Any]?,
+    context _: UnsafeMutableRawPointer?
+  ) {
+    if keyPath == ConfigurationName.hangulForceStrictCombinationRule {
+      let lastHangulInputMode = configuration.lastHangulInputMode
+      let inputSource = GureumInputSource(rawValue: lastHangulInputMode) ?? .han2
+      let keyboard = inputSource.keyboardIdentifier
+      setKeyboard(identifier: keyboard)
+    } else {
+      inputContext.setOption(HANGUL_IC_OPTION_AUTO_REORDER, value: configuration.hangulAutoReorder)
+      inputContext.setOption(
+        HANGUL_IC_OPTION_NON_CHOSEONG_COMBI, value: configuration.hangulNonChoseongCombination)
+    }
+  }
+
+  deinit {
+    configuration.removeObserver(self, forKeyPath: ConfigurationName.hangulAutoReorder)
+    configuration.removeObserver(self, forKeyPath: ConfigurationName.hangulNonChoseongCombination)
+    configuration.removeObserver(
+      self, forKeyPath: ConfigurationName.hangulForceStrictCombinationRule)
+  }
+
+  // MARK: Composer 프로토콜 구현
+
+  var composedString: String {
+    let preedit = inputContext.preeditUCSString
+    return _composedString + representableString(ucsString: preedit)
+  }
+
+  var originalString: String {
+    let preedit = inputContext.preeditUCSString
+    return _composedString + representableString(ucsString: preedit)
+  }
+
+  var commitString: String {
+    return _commitString
+  }
+
+  var candidates: [NSAttributedString]? {
+    return nil
+  }
+
+  var hasCandidates: Bool {
+    return false
+  }
+
+  func clear() {
+    clearCompositionContext()
+  }
+
+  @discardableResult
+  func dequeueCommitString() -> String {
+    let queuedCommitString = _commitString
+    _commitString = ""
+    return queuedCommitString
+  }
+
+  func cancelComposition() {
+    let flushedString: String! = representableString(ucsString: inputContext.flushUCSString())
+    _commitString.append(_composedString)
+    _commitString.append(flushedString)
+    _composedString = ""
+  }
+
+  func clearCompositionContext() {
+    inputContext.reset()
+    _commitString = ""
+    _composedString = ""
+  }
+
+  func composerSelected() {
+    clear()
+  }
+
+  func candidateSelected(_: NSAttributedString) {
+    assertionFailure()
+  }
+
+  func candidateSelectionChanged(_: NSAttributedString) {
+    assertionFailure()
+  }
+
+  func input(
+    text string: String?,
+    key keyCode: KeyCode,
+    modifiers flags: NSEvent.ModifierFlags,
+    client _: IMKTextInput & IMKUnicodeTextInput
+  ) -> InputResult {
+    // libhangul은 backspace를 키로 받지 않고 별도로 처리한다.
+    if keyCode == .delete {
+      // JDK 호환 모드의 경우, _composedString가 있을 경우 그 문자를 우선적으로 지운다
+      if configuration.hangulDeferredSymbolCommit, !_composedString.isEmpty {
+        _composedString.removeLast()
+        return .processed
+      }
+      return inputContext.backspace() ? .processed : .notProcessed
     }
 
-    /// 합성을 완료한 문자열.
-    private var _commitString: String
-    /// 합성 중인 문자열. 현재는 JDK 호환 모드에만 사용된다.
-    private var _composedString: String
-
-    let inputContext: HGInputContext
-    let configuration = Configuration.shared
-
-    init(type: HangulComposer.ComposerType) {
-        _commitString = ""
-        _composedString = ""
-        let keyboardIdentifier = type.rawValue
-        let inputContext = HGInputContext(keyboardIdentifier: keyboardIdentifier)!
-        self.inputContext = inputContext
-        self.inputContext.setOption(HANGUL_IC_OPTION_AUTO_REORDER, value: configuration.hangulAutoReorder)
-        self.inputContext.setOption(HANGUL_IC_OPTION_NON_CHOSEONG_COMBI, value: configuration.hangulNonChoseongCombination)
-        super.init()
-        configuration.addObserver(self, forKeyPath: ConfigurationName.hangulAutoReorder, options: .new, context: nil)
-        configuration.addObserver(self, forKeyPath: ConfigurationName.hangulNonChoseongCombination, options: .new, context: nil)
-        configuration.addObserver(self, forKeyPath: ConfigurationName.hangulForceStrictCombinationRule, options: .new, context: nil)
+    if !keyCode.isKeyMappable || [.delete, .return, .tab, .space].contains(keyCode) {
+      dlog(debugHangulComposer, " ** ESCAPE from outbound keyCode: %lu", keyCode.rawValue)
+      return InputResult(processed: false, action: .commit)
     }
 
-    override func observeValue(forKeyPath keyPath: String?, of _: Any?, change _: [NSKeyValueChangeKey: Any]?, context _: UnsafeMutableRawPointer?) {
-        if keyPath == ConfigurationName.hangulForceStrictCombinationRule {
-            let lastHangulInputMode = configuration.lastHangulInputMode
-            let inputSource = GureumInputSource(rawValue: lastHangulInputMode) ?? .han2
-            let keyboard = inputSource.keyboardIdentifier
-            setKeyboard(identifier: keyboard)
-        } else {
-            inputContext.setOption(HANGUL_IC_OPTION_AUTO_REORDER, value: configuration.hangulAutoReorder)
-            inputContext.setOption(HANGUL_IC_OPTION_NON_CHOSEONG_COMBI, value: configuration.hangulNonChoseongCombination)
-        }
+    var string = string!
+    // 한글 입력에서 캡스락 무시
+    if flags.contains(.shift) {
+      string = keyMapUpper[keyCode.rawValue] ?? string
+    } else {
+      string = keyMapLower[keyCode.rawValue] ?? string
     }
+    let handled = inputContext.process(string.unicodeScalars.first!.value)
+    let ucsString = inputContext.commitUCSString
+    let recentCommitString = representableString(ucsString: ucsString)
 
-    deinit {
-        configuration.removeObserver(self, forKeyPath: ConfigurationName.hangulAutoReorder)
-        configuration.removeObserver(self, forKeyPath: ConfigurationName.hangulNonChoseongCombination)
-        configuration.removeObserver(self, forKeyPath: ConfigurationName.hangulForceStrictCombinationRule)
-    }
-
-    // MARK: Composer 프로토콜 구현
-
-    var composedString: String {
-        let preedit = inputContext.preeditUCSString
-        return _composedString + representableString(ucsString: preedit)
-    }
-
-    var originalString: String {
-        let preedit = inputContext.preeditUCSString
-        return _composedString + representableString(ucsString: preedit)
-    }
-
-    var commitString: String {
-        return _commitString
-    }
-
-    var candidates: [NSAttributedString]? {
-        return nil
-    }
-
-    var hasCandidates: Bool {
-        return false
-    }
-
-    func clear() {
-        clearCompositionContext()
-    }
-
-    @discardableResult
-    func dequeueCommitString() -> String {
-        let queuedCommitString = _commitString
-        _commitString = ""
-        return queuedCommitString
-    }
-
-    func cancelComposition() {
-        let flushedString: String! = representableString(ucsString: inputContext.flushUCSString())
+    if configuration.hangulDeferredSymbolCommit {
+      if handled {
         _commitString.append(_composedString)
-        _commitString.append(flushedString)
         _composedString = ""
-    }
-
-    func clearCompositionContext() {
-        inputContext.reset()
-        _commitString = ""
-        _composedString = ""
-    }
-
-    func composerSelected() {
-        clear()
-    }
-
-    func candidateSelected(_: NSAttributedString) {
-        assertionFailure()
-    }
-
-    func candidateSelectionChanged(_: NSAttributedString) {
-        assertionFailure()
-    }
-
-    func input(text string: String?,
-               key keyCode: KeyCode,
-               modifiers flags: NSEvent.ModifierFlags,
-               client _: IMKTextInput & IMKUnicodeTextInput) -> InputResult
-    {
-        // libhangul은 backspace를 키로 받지 않고 별도로 처리한다.
-        if keyCode == .delete {
-            // JDK 호환 모드의 경우, _composedString가 있을 경우 그 문자를 우선적으로 지운다
-            if configuration.hangulDeferredSymbolCommit, !_composedString.isEmpty {
-                _composedString.removeLast()
-                return .processed
-            }
-            return inputContext.backspace() ? .processed : .notProcessed
-        }
-
-        if !keyCode.isKeyMappable || [.delete, .return, .tab, .space].contains(keyCode) {
-            dlog(DEBUG_HANGULCOMPOSER, " ** ESCAPE from outbound keyCode: %lu", keyCode.rawValue)
-            return InputResult(processed: false, action: .commit)
-        }
-
-        var string = string!
-        // 한글 입력에서 캡스락 무시
-        if flags.contains(.shift) {
-            string = KeyMapUpper[keyCode.rawValue] ?? string
+        if recentCommitString.isEmpty {
+          return .processed
         } else {
-            string = KeyMapLower[keyCode.rawValue] ?? string
-        }
-        let handled = inputContext.process(string.unicodeScalars.first!.value)
-        let ucsString = inputContext.commitUCSString
-        let recentCommitString = representableString(ucsString: ucsString)
-
-        if configuration.hangulDeferredSymbolCommit {
-            if handled {
-                _commitString.append(_composedString)
-                _composedString = ""
-                if recentCommitString.isEmpty {
-                    return .processed
-                } else {
-                    // 커밋 대상 문자열 중 마지막 문자가 한글이 아닌 경우 비조합 문자로 판단한다.
-                    let lastChar = String(recentCommitString.last!)
-                    if lastChar.range(of: "[ㄱ-ㅎㅏ-ㅣ가-힣]", options: .regularExpression) == nil {
-                        // 이 때, 마지막 문자가 입력기의 처리를 거치지 않은 것과 동일한 경우에는 deferred 모드를 사용하지 않는다.
-                        if lastChar == string {
-                            _commitString.append(recentCommitString)
-                            return .processed
-                        } else {
-                            _composedString = lastChar
-                            _commitString.append(String(recentCommitString.dropLast()))
-                        }
-                    } else {
-                        _commitString.append(recentCommitString)
-                    }
-                    return .processed
-                }
+          // 커밋 대상 문자열 중 마지막 문자가 한글이 아닌 경우 비조합 문자로 판단한다.
+          let lastChar = String(recentCommitString.last!)
+          if lastChar.range(of: "[ㄱ-ㅎㅏ-ㅣ가-힣]", options: .regularExpression) == nil {
+            // 이 때, 마지막 문자가 입력기의 처리를 거치지 않은 것과 동일한 경우에는 deferred 모드를 사용하지 않는다.
+            if lastChar == string {
+              _commitString.append(recentCommitString)
+              return .processed
             } else {
-                return InputResult(processed: false, action: .cancel)
+              _composedString = lastChar
+              _commitString.append(String(recentCommitString.dropLast()))
             }
+          } else {
+            _commitString.append(recentCommitString)
+          }
+          return .processed
         }
-
-        if configuration.hangulWonCurrencySymbolForBackQuote, keyCode == .ansiGrave, flags.isSubset(of: .capsLock) {
-            if !handled {
-                _commitString.append(recentCommitString + "₩")
-                return .processed
-            } else if recentCommitString.last! == "`" {
-                _commitString.append(recentCommitString.dropLast() + "₩")
-                return .processed
-            }
-        }
-
-        _commitString.append(recentCommitString)
-        // dlog(DEBUG_HANGULCOMPOSER, @"HangulComposer -inputText: string %@ (%@ added)", self->_commitString, recentCommitString)
-        return handled ? .processed : InputResult(processed: false, action: .cancel)
+      } else {
+        return InputResult(processed: false, action: .cancel)
+      }
     }
+
+    if configuration.hangulWonCurrencySymbolForBackQuote, keyCode == .ansiGrave,
+      flags.isSubset(of: .capsLock)
+    {
+      if !handled {
+        _commitString.append(recentCommitString + "₩")
+        return .processed
+      } else if recentCommitString.last! == "`" {
+        _commitString.append(recentCommitString.dropLast() + "₩")
+        return .processed
+      }
+    }
+
+    _commitString.append(recentCommitString)
+    // dlog(debugHangulComposer, @"HangulComposer -inputText: string %@ (%@ added)", self->_commitString, recentCommitString)
+    return handled ? .processed : InputResult(processed: false, action: .cancel)
+  }
 }
 
 extension HangulComposer {
-    /// 현재 context의 배열을 바꾼다.
-    ///
-    /// - Parameter identifier: `libhangul`의 `hangul_ic_select_keyboard`를 참고한다.
-    func setKeyboard(identifier: String) {
-        if configuration.hangulForceStrictCombinationRule, identifier == "39" || identifier == "3f" {
-            let strictCombinationIdentifier = "\(identifier)s"
-            inputContext.setKeyboardWithIdentifier(strictCombinationIdentifier)
-        } else {
-            inputContext.setKeyboardWithIdentifier(identifier)
-        }
+  /// 현재 context의 배열을 바꾼다.
+  ///
+  /// - Parameter identifier: `libhangul`의 `hangul_ic_select_keyboard`를 참고한다.
+  func setKeyboard(identifier: String) {
+    if configuration.hangulForceStrictCombinationRule, identifier == "39" || identifier == "3f" {
+      let strictCombinationIdentifier = "\(identifier)s"
+      inputContext.setKeyboardWithIdentifier(strictCombinationIdentifier)
+    } else {
+      inputContext.setKeyboardWithIdentifier(identifier)
     }
+  }
 
-    private func input(controller _: InputController, command _: String?, key _: Int, modifiers _: NSEvent.ModifierFlags, client _: Any) -> InputResult {
-        assertionFailure()
-        return .notProcessed
-    }
+  private func input(
+    controller _: InputController, command _: String?, key _: Int,
+    modifiers _: NSEvent.ModifierFlags, client _: Any
+  ) -> InputResult {
+    assertionFailure()
+    return .notProcessed
+  }
 }

--- a/OSXCore/InputController.swift
+++ b/OSXCore/InputController.swift
@@ -9,402 +9,415 @@
 import Foundation
 import InputMethodKit
 
-let DEBUG_LOGGING = false
-let DEBUG_INPUTCONTROLLER = false
-let DEBUG_SPYING = true
+let debugLogging = false
+let debugInputController = false
+let debugSpying = true
 
-/*!
- @enum
- @brief  최종적으로 InputController가 처리할 결과
- */
+//! @enum
+//! @brief  최종적으로 InputController가 처리할 결과
 
 public enum InputAction: Equatable {
-    case none
-    case commit
-    case cancel
-    case layout(String)
-    case candidatesEvent(KeyCode) // keyCode
+  case none
+  case commit
+  case cancel
+  case layout(String)
+  case candidatesEvent(KeyCode)  // keyCode
 }
 
 struct InputResult: Equatable {
-    let processed: Bool
-    let action: InputAction
+  let processed: Bool
+  let action: InputAction
 
-    static let processed = InputResult(processed: true, action: .none)
-    static let notProcessed = InputResult(processed: false, action: .none)
+  static let processed = InputResult(processed: true, action: .none)
+  static let notProcessed = InputResult(processed: false, action: .none)
 }
 
 enum ChangeLayout {
-    case toggle
-    case toggleByCapsLock
-    case toggleByRightKey
-    case hangul
-    case roman
-    case search
+  case toggle
+  case toggleByCapsLock
+  case toggleByRightKey
+  case hangul
+  case roman
+  case search
 }
 
 enum InputEvent {
-    case changeLayout(ChangeLayout, Bool)
+  case changeLayout(ChangeLayout, Bool)
 }
 
 @objc(GureumInputController)
 public class InputController: IMKInputController {
-    var receiver: InputReceiver!
-    var lastFlags = NSEvent.ModifierFlags(rawValue: 0)
-    var updating = false
+  var receiver: InputReceiver!
+  var lastFlags = NSEvent.ModifierFlags(rawValue: 0)
+  var updating = false
 
-    override init!(server: IMKServer, delegate: Any!, client inputClient: Any) {
-        super.init(server: server, delegate: delegate, client: inputClient)
-        guard let inputClient = inputClient as? (IMKTextInput & IMKUnicodeTextInput) else {
-            return nil
-        }
-        dlog(DEBUG_INPUTCONTROLLER, "**** NEW INPUT CONTROLLER INIT **** WITH SERVER: \(server) / DELEGATE: \(String(describing: delegate)) / CLIENT: \(inputClient) \(inputClient.bundleIdentifier() ?? "nil")")
-        assert(InputMethodServer.shared.server === server)
-        receiver = InputReceiver(server: server, delegate: delegate, client: inputClient, controller: self)
+  override init!(server: IMKServer, delegate: Any!, client inputClient: Any) {
+    super.init(server: server, delegate: delegate, client: inputClient)
+    guard let inputClient = inputClient as? (IMKTextInput & IMKUnicodeTextInput) else {
+      return nil
     }
+    dlog(
+      debugInputController,
+      "**** NEW INPUT CONTROLLER INIT **** WITH SERVER: \(server) / DELEGATE: \(String(describing: delegate)) / CLIENT: \(inputClient) \(inputClient.bundleIdentifier() ?? "nil")"
+    )
+    assert(InputMethodServer.shared.server === server)
+    receiver = InputReceiver(
+      server: server, delegate: delegate, client: inputClient, controller: self)
+  }
 
-    override init() {
-        super.init()
-    }
+  override init() {
+    super.init()
+  }
 
-    override public func inputControllerWillClose() {
-        super.inputControllerWillClose()
-    }
+  override public func inputControllerWillClose() {
+    super.inputControllerWillClose()
+  }
 
-    func asClient(_ sender: Any!) -> IMKTextInput & IMKUnicodeTextInput {
-        #if DEBUG
-            return sender as! (IMKTextInput & IMKUnicodeTextInput)
-        #else
-            guard let sender = sender as? (IMKTextInput & IMKUnicodeTextInput) else {
-                return client() as! (IMKTextInput & IMKUnicodeTextInput)
-            }
-            return sender
-        #endif
-    }
-
+  func asClient(_ sender: Any!) -> IMKTextInput & IMKUnicodeTextInput {
     #if DEBUG
-        override public func responds(to aSelector: Selector) -> Bool {
-            let r = super.responds(to: aSelector)
-            dlog(DEBUG_SPYING, "controller responds to: \(aSelector) \(r)")
-            return r
-        }
-
-        override public func modes(_ sender: Any!) -> [AnyHashable: Any]! {
-            let modes = super.modes(sender)
-            dlog(DEBUG_SPYING, "modes: \(String(describing: modes))")
-            return modes
-        }
-
-        override public func value(forTag tag: Int, client _: Any!) -> Any! {
-            let v = super.value(forTag: tag, client: client)
-            dlog(DEBUG_SPYING, "value: \(String(describing: v)) for tag: \(tag)")
-            return v
-        }
+      return sender as! (IMKTextInput & IMKUnicodeTextInput)
+    #else
+      guard let sender = sender as? (IMKTextInput & IMKUnicodeTextInput) else {
+        return client() as! (IMKTextInput & IMKUnicodeTextInput)
+      }
+      return sender
     #endif
+  }
+
+  #if DEBUG
+    override public func responds(to aSelector: Selector) -> Bool {
+      let r = super.responds(to: aSelector)
+      dlog(debugSpying, "controller responds to: \(aSelector) \(r)")
+      return r
+    }
+
+    override public func modes(_ sender: Any!) -> [AnyHashable: Any]! {
+      let modes = super.modes(sender)
+      dlog(debugSpying, "modes: \(String(describing: modes))")
+      return modes
+    }
+
+    override public func value(forTag tag: Int, client _: Any!) -> Any! {
+      let v = super.value(forTag: tag, client: client)
+      dlog(debugSpying, "value: \(String(describing: v)) for tag: \(tag)")
+      return v
+    }
+  #endif
 }
 
 // IMKServerInputTextData, IMKServerInputHandleEvent, IMKServerInputKeyBinding 중 하나를 구현하여 입력 구현
-public extension InputController { // IMKServerInputHandleEvent
-    // Receiving Events Directly from the Text Services Manager
+extension InputController {  // IMKServerInputHandleEvent
+  // Receiving Events Directly from the Text Services Manager
 
-    override func handle(_ event: NSEvent, client sender: Any) -> Bool {
-        // dlog(DEBUG_INPUTCONTROLLER, "event: \(event)")
-        // sender is (IMKTextInput & IMKUnicodeTextInput & IMTSMSupport)
-        let client = asClient(sender)
+  public override func handle(_ event: NSEvent, client sender: Any) -> Bool {
+    // dlog(debugInputController, "event: \(event)")
+    // sender is (IMKTextInput & IMKUnicodeTextInput & IMTSMSupport)
+    let client = asClient(sender)
 
-        switch event.type {
-        case .keyDown:
-            guard let keyCode = KeyCode(rawValue: Int(event.keyCode)) else {
-                return false
-            }
-
-            dlog(DEBUG_INPUTCONTROLLER, "** InputController KEYDOWN -handleEvent:client: with event: %@ / key: %d / modifier: %lu / chars: %@ / chars ignoreMod: %@ / client: %@", event, event.keyCode, event.modifierFlags.rawValue, event.characters ?? "(empty)", event.charactersIgnoringModifiers ?? "(empty)", client.bundleIdentifier() ?? "(no client bundle)")
-
-            let imkCandidates = InputMethodServer.shared.candidates
-            if imkCandidates.isVisible() {
-                let selectionKeys = imkCandidates.selectionKeys() as? [NSNumber] ?? []
-                let arrowModifier = NSEvent.ModifierFlags.numericPad.union(.function)
-                let emptyModifier = NSEvent.ModifierFlags(rawValue: 0)
-
-                let inputModifier = event.modifierFlags
-                    .intersection(.deviceIndependentFlagsMask)
-                    .subtracting(.capsLock)
-
-                if inputModifier == arrowModifier && KeyCode.arrows.contains(keyCode) || inputModifier == emptyModifier && (keyCode == .return || selectionKeys.contains(NSNumber(value: event.keyCode))) {
-                    // https://github.com/pkamb/NumberInput_IMKit_Sample/issues/1#issuecomment-633264470
-                    imkCandidates.perform(Selector(("handleKeyboardEvent:")), with: event)
-                    return true
-                }
-            }
-
-            let result = receiver.input(text: event.characters, key: keyCode, modifiers: event.modifierFlags, client: client)
-            dlog(DEBUG_LOGGING, "LOGGING::PROCESSED::\(result)")
-            return result.processed
-        case .flagsChanged:
-            dlog(DEBUG_INPUTCONTROLLER, "** InputController FLAGCHANGED -handleEvent:client: with event: %@ / key: %d / modifier: %lu / client: %@", event, -1, event.modifierFlags.rawValue, client.bundleIdentifier() ?? "(no client bundle)")
-            let changed = lastFlags.symmetricDifference(event.modifierFlags)
-            lastFlags = event.modifierFlags
-
-            if changed.contains(.capsLock), Configuration.shared.enableCapslockToToggleInputMode {
-                if InputMethodServer.shared.io.capsLockTriggered {
-                    dlog(DEBUG_IOKIT_EVENT, "controller detected capslock to change layout")
-                    let toggle = { [weak self] in _ = self?.receiver.input(event: .changeLayout(.toggleByCapsLock, true), client: client) }
-                    toggle()
-                    InputMethodServer.shared.io.rollback = toggle
-                } else {
-                    dlog(DEBUG_IOKIT_EVENT, "controller detected capslock")
-                    (sender as! IMKTextInput).selectMode(receiver.composer.inputMode)
-                }
-            }
-
-            if InputMethodServer.shared.io.resolveRightKeyPressed() {
-                let result = receiver.input(event: .changeLayout(.toggleByRightKey, true), client: client)
-                dlog(DEBUG_IOKIT_EVENT, "controller detected right key")
-                return result.processed
-            }
-
-            dlog(DEBUG_LOGGING, "LOGGING::UNHANDLED::%@/%@", event, sender as! NSObject)
-            dlog(DEBUG_INPUTCONTROLLER, "** InputController -handleEvent:client: with event: %@ / sender: %@", event, sender as! NSObject)
-            return false
-        case .leftMouseDown, .leftMouseUp, .leftMouseDragged, .rightMouseDown, .rightMouseUp, .rightMouseDragged:
-            commitComposition(sender)
-        default:
-            dlog(DEBUG_SPYING, "unhandled event: \(event)")
-        }
+    switch event.type {
+    case .keyDown:
+      guard let keyCode = KeyCode(rawValue: Int(event.keyCode)) else {
         return false
-    }
-}
+      }
 
-/*
- extension InputController { // IMKServerInputTextData
- override func inputText(_ string: String!, key keyCode: Int, modifiers flags: Int, client sender: Any) -> Bool {
- dlog(DEBUG_INPUTCONTROLLER, "** InputController -inputText:key:modifiers:client  with string: %@ / keyCode: %ld / modifier flags: %lu / client: %@", string, keyCode, flags, client()?.bundleIdentifier() ?? "nil")
- let processed = receiver.input(controller: self, inputText: string, key: keyCode, modifiers: NSEvent.ModifierFlags(rawValue: UInt(flags)), client: sender).rawValue > CIMInputTextProcessResult.notProcessed.rawValue
- return processed
- }
- }
- */
-/*
- extension InputController { // IMKServerInputKeyBinding
- override func inputText(_: String!, client _: Any) -> Bool {
- // dlog(DEBUG_INPUTCONTROLLER, "** InputController -inputText:client: with string: %@ / client: %@", string, sender)
- return false
- }
+      dlog(
+        debugInputController,
+        "** InputController KEYDOWN -handleEvent:client: with event: %@ / key: %d / modifier: %lu / chars: %@ / chars ignoreMod: %@ / client: %@",
+        event, event.keyCode, event.modifierFlags.rawValue, event.characters ?? "(empty)",
+        event.charactersIgnoringModifiers ?? "(empty)",
+        client.bundleIdentifier() ?? "(no client bundle)")
 
- override func didCommand(by _: Selector!, client _: Any) -> Bool {
- // dlog(DEBUG_INPUTCONTROLLER, "** InputController -didCommandBySelector: with selector: %@", aSelector)
- return false
- }
- }
- */
+      let imkCandidates = InputMethodServer.shared.candidates
+      if imkCandidates.isVisible() {
+        let selectionKeys = imkCandidates.selectionKeys() as? [NSNumber] ?? []
+        let arrowModifier = NSEvent.ModifierFlags.numericPad.union(.function)
+        let emptyModifier = NSEvent.ModifierFlags(rawValue: 0)
 
-public extension InputController { // IMKStateSetting
-    //! @brief  마우스 이벤트를 잡을 수 있게 한다.
-    override func recognizedEvents(_ sender: Any!) -> Int {
-        let client = asClient(sender)
-        return Int(receiver.recognizedEvents(client).rawValue)
-    }
+        let inputModifier = event.modifierFlags
+          .intersection(.deviceIndependentFlagsMask)
+          .subtracting(.capsLock)
 
-    //! @brief 자판 전환을 감지한다.
-    override func setValue(_ value: Any, forTag tag: Int, client sender: Any) {
-        let client = asClient(sender)
-        receiver.setValue(value, forTag: tag, client: client)
-    }
-
-    override func activateServer(_ sender: Any!) {
-        dlog(true, "server activated")
-        super.activateServer(sender)
-    }
-
-    override func deactivateServer(_ sender: Any!) {
-        dlog(true, "server deactivating")
-        if responds(to: #selector(commitComposition(_:))) {
-            self.commitComposition(sender)
+        if inputModifier == arrowModifier && KeyCode.arrows.contains(keyCode)
+          || inputModifier == emptyModifier
+            && (keyCode == .return || selectionKeys.contains(NSNumber(value: event.keyCode)))
+        {
+          // https://github.com/pkamb/NumberInput_IMKit_Sample/issues/1#issuecomment-633264470
+          imkCandidates.perform(Selector(("handleKeyboardEvent:")), with: event)
+          return true
         }
-        super.deactivateServer(sender)
+      }
+
+      let result = receiver.input(
+        text: event.characters, key: keyCode, modifiers: event.modifierFlags, client: client)
+      dlog(debugLogging, "LOGGING::PROCESSED::\(result)")
+      return result.processed
+    case .flagsChanged:
+      dlog(
+        debugInputController,
+        "** InputController FLAGCHANGED -handleEvent:client: with event: %@ / key: %d / modifier: %lu / client: %@",
+        event, -1, event.modifierFlags.rawValue, client.bundleIdentifier() ?? "(no client bundle)")
+      let changed = lastFlags.symmetricDifference(event.modifierFlags)
+      lastFlags = event.modifierFlags
+
+      if changed.contains(.capsLock), Configuration.shared.enableCapslockToToggleInputMode {
+        if InputMethodServer.shared.io.capsLockTriggered {
+          dlog(debugIOKitEvent, "controller detected capslock to change layout")
+          let toggle = { [weak self] in
+            _ = self?.receiver.input(event: .changeLayout(.toggleByCapsLock, true), client: client)
+          }
+          toggle()
+          InputMethodServer.shared.io.rollback = toggle
+        } else {
+          dlog(debugIOKitEvent, "controller detected capslock")
+          (sender as! IMKTextInput).selectMode(receiver.composer.inputMode)
+        }
+      }
+
+      if InputMethodServer.shared.io.resolveRightKeyPressed() {
+        let result = receiver.input(event: .changeLayout(.toggleByRightKey, true), client: client)
+        dlog(debugIOKitEvent, "controller detected right key")
+        return result.processed
+      }
+
+      dlog(debugLogging, "LOGGING::UNHANDLED::%@/%@", event, sender as! NSObject)
+      dlog(
+        debugInputController,
+        "** InputController -handleEvent:client: with event: %@ / sender: %@", event,
+        sender as! NSObject)
+      return false
+    case .leftMouseDown, .leftMouseUp, .leftMouseDragged, .rightMouseDown, .rightMouseUp,
+      .rightMouseDragged:
+      commitComposition(sender)
+    default:
+      dlog(debugSpying, "unhandled event: \(event)")
     }
+    return false
+  }
 }
 
-public extension InputController { // IMKMouseHandling
-    /*!
-     @brief  마우스 입력 발생을 커서 옮기기로 간주하고 조합 중지. 만일 마우스 입력 발생을 감지하는 대신 커서 옮기기를 직접 알아낼 수 있으면 이 부분은 제거한다.
-     */
-    override func mouseDown(onCharacterIndex _: Int, coordinate _: NSPoint, withModifier _: Int, continueTracking _: UnsafeMutablePointer<ObjCBool>!, client sender: Any) -> Bool {
-        dlog(DEBUG_LOGGING, "LOGGING::EVENT::MOUSEDOWN")
-        commitComposition(sender)
-        return false
+extension InputController {  // IMKStateSetting
+  //! @brief  마우스 이벤트를 잡을 수 있게 한다.
+  public override func recognizedEvents(_ sender: Any!) -> Int {
+    let client = asClient(sender)
+    return Int(receiver.recognizedEvents(client).rawValue)
+  }
+
+  //! @brief 자판 전환을 감지한다.
+  public override func setValue(_ value: Any, forTag tag: Int, client sender: Any) {
+    let client = asClient(sender)
+    receiver.setValue(value, forTag: tag, client: client)
+  }
+
+  public override func activateServer(_ sender: Any!) {
+    dlog(true, "server activated")
+    super.activateServer(sender)
+  }
+
+  public override func deactivateServer(_ sender: Any!) {
+    dlog(true, "server deactivating")
+    if responds(to: #selector(commitComposition(_:))) {
+      self.commitComposition(sender)
     }
+    super.deactivateServer(sender)
+  }
 }
 
-public extension InputController { // IMKCustomCommands
-    override func menu() -> NSMenu! {
-        return (NSApplication.shared.delegate! as! GureumApplicationDelegate).menu
-    }
+extension InputController {  // IMKMouseHandling
+  //! @brief  마우스 입력 발생을 커서 옮기기로 간주하고 조합 중지. 만일 마우스 입력 발생을 감지하는 대신 커서 옮기기를 직접 알아낼 수 있으면 이 부분은 제거한다.
+  public override func mouseDown(
+    onCharacterIndex _: Int, coordinate _: NSPoint, withModifier _: Int,
+    continueTracking _: UnsafeMutablePointer<ObjCBool>!, client sender: Any
+  ) -> Bool {
+    dlog(debugLogging, "LOGGING::EVENT::MOUSEDOWN")
+    commitComposition(sender)
+    return false
+  }
 }
 
-public extension InputController { // IMKServerInput
+extension InputController {  // IMKCustomCommands
+  public override func menu() -> NSMenu! {
+    return (NSApplication.shared.delegate! as! GureumApplicationDelegate).menu
+  }
+}
+
+extension InputController {  // IMKServerInput
+  // Committing a Composition
+  // 조합을 중단하고 현재까지 조합된 글자를 커밋한다.
+  @objc public override func commitComposition(_ sender: Any!) {
+    let client = asClient(sender)
+    dlog(debugLogging, "LOGGING::EVENT::COMMIT-RAW?")
+    _ = receiver.commitCompositionEvent(client)
+    // super.commitComposition(sender)
+  }
+
+  @objc public override func updateComposition() {
+    dlog(debugLogging, "LOGGING::EVENT::UPDATE-RAW?")
+    dlog(debugInputController, "** InputController -updateComposition")
+    receiver.updateCompositionEvent()
+    super.updateComposition()
+    dlog(debugInputController, "** InputController -updateComposition ended")
+  }
+
+  @objc public override func cancelComposition() {
+    dlog(debugLogging, "LOGGING::EVENT::CANCEL-RAW?")
+    receiver.cancelCompositionEvent()
+    super.cancelComposition()
+  }
+
+  // Getting Input Strings and Candidates
+  // 현재 입력 중인 글자를 반환한다. -updateComposition: 이 사용
+  @objc public override func composedString(_ sender: Any!) -> Any {
+    let client = asClient(sender)
+    return receiver.composedString(client)
+  }
+
+  @objc public override func originalString(_ sender: Any!) -> NSAttributedString {
+    let client = asClient(sender)
+    return receiver.originalString(client)
+  }
+
+  @objc public override func candidates(_ sender: Any!) -> [Any]! {
+    let client = asClient(sender)
+    return receiver.candidates(client)
+  }
+
+  @objc public override func candidateSelected(_ candidateString: NSAttributedString!) {
+    receiver.candidateSelected(candidateString)
+  }
+
+  @objc public override func candidateSelectionChanged(_ candidateString: NSAttributedString!) {
+    receiver.candidateSelectionChanged(candidateString)
+  }
+}
+
+#if DEBUG
+  @objcMembers public class MockInputController: InputController {
+    override public init(server: IMKServer, delegate: Any!, client: Any) {
+      super.init()
+      receiver = InputReceiver(
+        server: server, delegate: delegate, client: client as! (IMKTextInput & IMKUnicodeTextInput),
+        controller: self)
+    }
+
+    func repoduceTextLog(_ text: String) throws {
+      for row in text.components(separatedBy: "\n") {
+        guard let regex = try? NSRegularExpression(pattern: "LOGGING::([A-Z]+)::(.*)", options: [])
+        else {
+          throw NSException(
+            name: NSExceptionName("MockInputControllerLogParserError"),
+            reason: "Log is not readable format", userInfo: nil) as! Error
+        }
+        let matches = regex.matches(in: row, options: [], range: NSRangeFromString(row))
+        let type = matches[1]
+        let data = matches[2]
+        print("test: \(type) \(data)")
+      }
+    }
+
+    override public func client() -> (IMKTextInput & NSObjectProtocol)! {
+      return receiver.inputClient as? (IMKTextInput & NSObjectProtocol)
+    }
+
+    override public func selectionRange() -> NSRange {
+      return client().selectedRange()
+    }
+  }
+
+  extension MockInputController {  // IMKServerInputTextData
+    public func inputFlags(_: Int, client sender: Any) -> Bool {
+      let client = asClient(sender)
+      let result = receiver.input(event: .changeLayout(.toggle, true), client: client)
+      if !result.processed {
+        // [self cancelComposition]
+      }
+      return result.processed
+    }
+
+    public override func inputText(
+      _ string: String!, key keyCode: Int, modifiers flags: Int, client sender: Any
+    ) -> Bool {
+      let client = asClient(sender)
+      print(
+        "** InputController -inputText:key:modifiers:client  with string: \(string ?? "(nil)") / keyCode: \(keyCode) / modifier flags: \(flags) / client: \(String(describing: client))"
+      )
+      guard let key = KeyCode(rawValue: keyCode) else { return false }
+      let result = receiver.input(
+        text: string, key: key, modifiers: NSEvent.ModifierFlags(rawValue: UInt(flags)),
+        client: client)
+      if !result.processed {
+        // [self cancelComposition]
+      }
+      return result.processed
+    }
+
     // Committing a Composition
     // 조합을 중단하고 현재까지 조합된 글자를 커밋한다.
-    @objc override func commitComposition(_ sender: Any!) {
-        let client = asClient(sender)
-        dlog(DEBUG_LOGGING, "LOGGING::EVENT::COMMIT-RAW?")
-        _ = receiver.commitCompositionEvent(client)
-        // super.commitComposition(sender)
+    @objc public override func commitComposition(_ sender: Any) {
+      let client = asClient(sender)
+      receiver.commitCompositionEvent(client)
+      // COMMIT triggered
     }
 
-    @objc override func updateComposition() {
-        dlog(DEBUG_LOGGING, "LOGGING::EVENT::UPDATE-RAW?")
-        dlog(DEBUG_INPUTCONTROLLER, "** InputController -updateComposition")
-        receiver.updateCompositionEvent()
-        super.updateComposition()
-        dlog(DEBUG_INPUTCONTROLLER, "** InputController -updateComposition ended")
+    public override func updateComposition() {
+      receiver.updateCompositionEvent()
+
+      let client = receiver.inputClient
+      let composed = composedString(client) as! String
+      let markedRange = client.markedRange()
+      let view = receiver.inputClient as! NSTextView
+      view.setMarkedText(
+        composed, selectedRange: NSRange(location: 0, length: composed.count),
+        replacementRange: markedRange)
     }
 
-    @objc override func cancelComposition() {
-        dlog(DEBUG_LOGGING, "LOGGING::EVENT::CANCEL-RAW?")
-        receiver.cancelCompositionEvent()
-        super.cancelComposition()
+    public override func cancelComposition() {
+      receiver.cancelCompositionEvent()
+
+      let client = receiver.inputClient
+      let view = receiver.inputClient as! NSTextView
+      let markedRange = client.markedRange()
+      view.setMarkedText(
+        "", selectedRange: NSRange(location: markedRange.location, length: 0),
+        replacementRange: markedRange)
     }
 
     // Getting Input Strings and Candidates
     // 현재 입력 중인 글자를 반환한다. -updateComposition: 이 사용
-    @objc override func composedString(_ sender: Any!) -> Any {
-        let client = asClient(sender)
-        return receiver.composedString(client)
+    public override func composedString(_ sender: Any) -> Any {
+      let client = asClient(sender)
+      return receiver.composedString(client)
     }
 
-    @objc override func originalString(_ sender: Any!) -> NSAttributedString {
-        let client = asClient(sender)
-        return receiver.originalString(client)
+    public override func originalString(_ sender: Any) -> NSAttributedString {
+      let client = asClient(sender)
+      return receiver.originalString(client)
     }
 
-    @objc override func candidates(_ sender: Any!) -> [Any]! {
-        let client = asClient(sender)
-        return receiver.candidates(client)
+    public override func candidates(_ sender: Any) -> [Any]? {
+      let client = asClient(sender)
+      return receiver.candidates(client)
     }
 
-    @objc override func candidateSelected(_ candidateString: NSAttributedString!) {
-        receiver.candidateSelected(candidateString)
+    public override func candidateSelected(_ candidateString: NSAttributedString!) {
+      receiver.candidateSelected(candidateString)
     }
 
-    @objc override func candidateSelectionChanged(_ candidateString: NSAttributedString!) {
-        receiver.candidateSelectionChanged(candidateString)
+    public override func candidateSelectionChanged(_ candidateString: NSAttributedString!) {
+      receiver.candidateSelectionChanged(candidateString)
     }
-}
+  }
 
-#if DEBUG
-    @objcMembers public class MockInputController: InputController {
-        override public init(server: IMKServer, delegate: Any!, client: Any) {
-            super.init()
-            receiver = InputReceiver(server: server, delegate: delegate, client: client as! (IMKTextInput & IMKUnicodeTextInput), controller: self)
-        }
-
-        func repoduceTextLog(_ text: String) throws {
-            for row in text.components(separatedBy: "\n") {
-                guard let regex = try? NSRegularExpression(pattern: "LOGGING::([A-Z]+)::(.*)", options: []) else {
-                    throw NSException(name: NSExceptionName("MockInputControllerLogParserError"), reason: "Log is not readable format", userInfo: nil) as! Error
-                }
-                let matches = regex.matches(in: row, options: [], range: NSRangeFromString(row))
-                let type = matches[1]
-                let data = matches[2]
-                print("test: \(type) \(data)")
-            }
-        }
-
-        override public func client() -> (IMKTextInput & NSObjectProtocol)! {
-            return receiver.inputClient as? (IMKTextInput & NSObjectProtocol)
-        }
-
-        override public func selectionRange() -> NSRange {
-            return client().selectedRange()
-        }
+  extension MockInputController {  // IMKStateSetting
+    //! @brief  마우스 이벤트를 잡을 수 있게 한다.
+    public override func recognizedEvents(_ sender: Any) -> Int {
+      let client = asClient(sender)
+      return Int(receiver.recognizedEvents(client).rawValue)
     }
 
-    public extension MockInputController { // IMKServerInputTextData
-        func inputFlags(_: Int, client sender: Any) -> Bool {
-            let client = asClient(sender)
-            let result = receiver.input(event: .changeLayout(.toggle, true), client: client)
-            if !result.processed {
-                // [self cancelComposition]
-            }
-            return result.processed
-        }
-
-        override func inputText(_ string: String!, key keyCode: Int, modifiers flags: Int, client sender: Any) -> Bool {
-            let client = asClient(sender)
-            print("** InputController -inputText:key:modifiers:client  with string: \(string ?? "(nil)") / keyCode: \(keyCode) / modifier flags: \(flags) / client: \(String(describing: client))")
-            guard let key = KeyCode(rawValue: keyCode) else { return false }
-            let result = receiver.input(text: string, key: key, modifiers: NSEvent.ModifierFlags(rawValue: UInt(flags)), client: client)
-            if !result.processed {
-                // [self cancelComposition]
-            }
-            return result.processed
-        }
-
-        // Committing a Composition
-        // 조합을 중단하고 현재까지 조합된 글자를 커밋한다.
-        @objc override func commitComposition(_ sender: Any) {
-            let client = asClient(sender)
-            receiver.commitCompositionEvent(client)
-            // COMMIT triggered
-        }
-
-        override func updateComposition() {
-            receiver.updateCompositionEvent()
-
-            let client = receiver.inputClient
-            let composed = composedString(client) as! String
-            let markedRange = client.markedRange()
-            let view = receiver.inputClient as! NSTextView
-            view.setMarkedText(composed, selectedRange: NSRange(location: 0, length: composed.count), replacementRange: markedRange)
-        }
-
-        override func cancelComposition() {
-            receiver.cancelCompositionEvent()
-
-            let client = receiver.inputClient
-            let view = receiver.inputClient as! NSTextView
-            let markedRange = client.markedRange()
-            view.setMarkedText("", selectedRange: NSRange(location: markedRange.location, length: 0), replacementRange: markedRange)
-        }
-
-        // Getting Input Strings and Candidates
-        // 현재 입력 중인 글자를 반환한다. -updateComposition: 이 사용
-        override func composedString(_ sender: Any) -> Any {
-            let client = asClient(sender)
-            return receiver.composedString(client)
-        }
-
-        override func originalString(_ sender: Any) -> NSAttributedString {
-            let client = asClient(sender)
-            return receiver.originalString(client)
-        }
-
-        override func candidates(_ sender: Any) -> [Any]? {
-            let client = asClient(sender)
-            return receiver.candidates(client)
-        }
-
-        override func candidateSelected(_ candidateString: NSAttributedString!) {
-            receiver.candidateSelected(candidateString)
-        }
-
-        override func candidateSelectionChanged(_ candidateString: NSAttributedString!) {
-            receiver.candidateSelectionChanged(candidateString)
-        }
+    //! @brief 자판 전환을 감지한다.
+    public override func setValue(_ value: Any, forTag tag: Int, client sender: Any) {
+      let client = asClient(sender)
+      receiver.setValue(value, forTag: tag, client: client)
     }
-
-    public extension MockInputController { // IMKStateSetting
-        //! @brief  마우스 이벤트를 잡을 수 있게 한다.
-        override func recognizedEvents(_ sender: Any) -> Int {
-            let client = asClient(sender)
-            return Int(receiver.recognizedEvents(client).rawValue)
-        }
-
-        //! @brief 자판 전환을 감지한다.
-        override func setValue(_ value: Any, forTag tag: Int, client sender: Any) {
-            let client = asClient(sender)
-            receiver.setValue(value, forTag: tag, client: client)
-        }
-    }
+  }
 #endif

--- a/OSXCore/InputMethodServer.swift
+++ b/OSXCore/InputMethodServer.swift
@@ -10,188 +10,198 @@ import Foundation
 import InputMethodKit
 import SwiftIOKit
 
-let DEBUG_INPUT_SERVER = false
-let DEBUG_IOKIT_EVENT = false
+let debugInputServer = false
+let debugIOKitEvent = false
 
 extension IMKServer {
-    convenience init?(bundle: Bundle) {
-        guard let connectionName = bundle.infoDictionary!["InputMethodConnectionName"] as? String else {
-            return nil
-        }
-        self.init(name: connectionName, bundleIdentifier: bundle.bundleIdentifier)
+  convenience init?(bundle: Bundle) {
+    guard let connectionName = bundle.infoDictionary!["InputMethodConnectionName"] as? String else {
+      return nil
     }
+    self.init(name: connectionName, bundleIdentifier: bundle.bundleIdentifier)
+  }
 }
 
 class IOKitty {
-    let service: SIOService
-    let connect: SIOConnect
-    let manager: IOHIDManager
-    private var defaultCapsLockState: Bool = false
-    var capsLockDate: Date?
-    var rollback: (() -> Void)?
-    var rightKeyPressed = false
+  let service: SIOService
+  let connect: SIOConnect
+  let manager: IOHIDManager
+  private var defaultCapsLockState: Bool = false
+  var capsLockDate: Date?
+  var rollback: (() -> Void)?
+  var rightKeyPressed = false
 
-    init?() {
-        guard let _service = SIOService(name: kIOHIDSystemClass) else {
-            return nil
-        }
-        service = _service
-        guard let _connect = try? service.open(owningTask: mach_task_self_, type: kIOHIDParamConnectType).get() else {
-            return nil
-        }
-        connect = _connect
-
-        defaultCapsLockState = (try? connect.getModifierLock(selector: .capsLock).get()) ?? false
-
-        manager = IOHIDManager.create()
-        manager.setDeviceMatching(page: kHIDPage_GenericDesktop, usage: kHIDUsage_GD_Keyboard)
-        manager.setInputValueMatching(min: kHIDUsage_KeyboardCapsLock, max: kHIDUsage_KeyboardRightGUI)
-
-        let _self = Unmanaged.passUnretained(self)
-        // Set input value callback
-        manager.registerInputValueCallback({
-            inContext, _, _, value in
-            let usage = Int(value.element.usage)
-            guard usage == kHIDUsage_KeyboardCapsLock || (usage >= kHIDUsage_KeyboardRightControl && usage <= kHIDUsage_KeyboardRightGUI) else {
-                return
-            }
-            guard Configuration.shared.enableCapslockToToggleInputMode || Configuration.shared.rightToggleKey > 0 else {
-                return
-            }
-            guard let inContext = inContext else {
-                dlog(true, "IOKit callback inContext is nil - impossible")
-                return
-            }
-
-            let pressed = value.integerValue > 0
-            switch usage {
-            case kHIDUsage_KeyboardCapsLock:
-                guard Configuration.shared.enableCapslockToToggleInputMode else {
-                    return
-                }
-                dlog(DEBUG_IOKIT_EVENT, "caps lock pressed: \(pressed)")
-                let _self = Unmanaged<IOKitty>.fromOpaque(inContext).takeUnretainedValue()
-                if pressed {
-                    _self.capsLockDate = Date()
-                    dlog(DEBUG_IOKIT_EVENT, "caps lock pressed set in context")
-                } else {
-                    if _self.defaultCapsLockState || (_self.capsLockDate != nil && !_self.capsLockTriggered) {
-                        // long pressed
-                        _self.defaultCapsLockState = !_self.defaultCapsLockState
-                        _self.rollback?()
-                        _self.rollback = nil
-                    } else {
-                        // short pressed
-                        _ = _self.connect.setModifierLock(selector: .capsLock, state: _self.defaultCapsLockState)
-                        _self.capsLockDate = nil
-                    }
-                }
-            case Configuration.shared.rightToggleKey:
-                dlog(DEBUG_IOKIT_EVENT, "right toggle key pressed: \(pressed)")
-                let _self = Unmanaged<IOKitty>.fromOpaque(inContext).takeUnretainedValue()
-                if pressed {
-                    _self.rightKeyPressed = true
-                    dlog(DEBUG_IOKIT_EVENT, "right toggle key pressed set in context")
-                }
-            default:
-                break
-            }
-            // NSEvent.otherEvent(with: .applicationDefined, location: .zero, modifierFlags: .capsLock, timestamp: 0, windowNumber: 0, context: nil, subtype: 0, data1: 0, data2: 0)!
-        }, context: _self.toOpaque())
-
-        manager.schedule(runloop: .current, mode: .default)
-        let r = manager.open()
-        if r != kIOReturnSuccess {
-            dlog(DEBUG_IOKIT_EVENT, "IOHIDManagerOpen failed")
-        }
+  init?() {
+    guard let _service = SIOService(name: kIOHIDSystemClass) else {
+      return nil
     }
-
-    deinit {
-        manager.unschedule(runloop: .current, mode: .default)
-        manager.unregisterInputValueCallback()
-        let r = manager.close()
-        assert(r == 0)
+    service = _service
+    guard
+      let _connect = try? service.open(owningTask: mach_task_self_, type: kIOHIDParamConnectType)
+        .get()
+    else {
+      return nil
     }
+    connect = _connect
 
-    var capsLockTriggered: Bool {
-        dlog(DEBUG_IOKIT_EVENT, "  triggered: date \(String(describing: capsLockDate))")
-        guard let capsLockDate = capsLockDate else {
-            return false
+    defaultCapsLockState = (try? connect.getModifierLock(selector: .capsLock).get()) ?? false
+
+    manager = IOHIDManager.create()
+    manager.setDeviceMatching(page: kHIDPage_GenericDesktop, usage: kHIDUsage_GD_Keyboard)
+    manager.setInputValueMatching(min: kHIDUsage_KeyboardCapsLock, max: kHIDUsage_KeyboardRightGUI)
+
+    let _self = Unmanaged.passUnretained(self)
+    // Set input value callback
+    manager.registerInputValueCallback(
+      {
+        inContext, _, _, value in
+        let usage = Int(value.element.usage)
+        guard
+          usage == kHIDUsage_KeyboardCapsLock
+            || (usage >= kHIDUsage_KeyboardRightControl && usage <= kHIDUsage_KeyboardRightGUI)
+        else {
+          return
         }
-        let interval = Date().timeIntervalSince(capsLockDate)
-        dlog(DEBUG_IOKIT_EVENT, "  triggered: interval \(interval)")
-        return interval < 0.5
-    }
-
-    func resolveRightKeyPressed() -> Bool {
-        if !rightKeyPressed {
-            return false
+        guard
+          Configuration.shared.enableCapslockToToggleInputMode
+            || Configuration.shared.rightToggleKey > 0
+        else {
+          return
         }
-        rightKeyPressed = false
-        return true
+        guard let inContext = inContext else {
+          dlog(true, "IOKit callback inContext is nil - impossible")
+          return
+        }
+
+        let pressed = value.integerValue > 0
+        switch usage {
+        case kHIDUsage_KeyboardCapsLock:
+          guard Configuration.shared.enableCapslockToToggleInputMode else {
+            return
+          }
+          dlog(debugIOKitEvent, "caps lock pressed: \(pressed)")
+          let _self = Unmanaged<IOKitty>.fromOpaque(inContext).takeUnretainedValue()
+          if pressed {
+            _self.capsLockDate = Date()
+            dlog(debugIOKitEvent, "caps lock pressed set in context")
+          } else {
+            if _self.defaultCapsLockState || (_self.capsLockDate != nil && !_self.capsLockTriggered)
+            {
+              // long pressed
+              _self.defaultCapsLockState = !_self.defaultCapsLockState
+              _self.rollback?()
+              _self.rollback = nil
+            } else {
+              // short pressed
+              _ = _self.connect.setModifierLock(
+                selector: .capsLock, state: _self.defaultCapsLockState)
+              _self.capsLockDate = nil
+            }
+          }
+        case Configuration.shared.rightToggleKey:
+          dlog(debugIOKitEvent, "right toggle key pressed: \(pressed)")
+          let _self = Unmanaged<IOKitty>.fromOpaque(inContext).takeUnretainedValue()
+          if pressed {
+            _self.rightKeyPressed = true
+            dlog(debugIOKitEvent, "right toggle key pressed set in context")
+          }
+        default:
+          break
+        }
+        // NSEvent.otherEvent(with: .applicationDefined, location: .zero, modifierFlags: .capsLock, timestamp: 0, windowNumber: 0, context: nil, subtype: 0, data1: 0, data2: 0)!
+      }, context: _self.toOpaque())
+
+    manager.schedule(runloop: .current, mode: .default)
+    let r = manager.open()
+    if r != kIOReturnSuccess {
+      dlog(debugIOKitEvent, "IOHIDManagerOpen failed")
     }
+  }
+
+  deinit {
+    manager.unschedule(runloop: .current, mode: .default)
+    manager.unregisterInputValueCallback()
+    let r = manager.close()
+    assert(r == 0)
+  }
+
+  var capsLockTriggered: Bool {
+    dlog(debugIOKitEvent, "  triggered: date \(String(describing: capsLockDate))")
+    guard let capsLockDate = capsLockDate else {
+      return false
+    }
+    let interval = Date().timeIntervalSince(capsLockDate)
+    dlog(debugIOKitEvent, "  triggered: interval \(interval)")
+    return interval < 0.5
+  }
+
+  func resolveRightKeyPressed() -> Bool {
+    if !rightKeyPressed {
+      return false
+    }
+    rightKeyPressed = false
+    return true
+  }
 }
 
-/*!
- @brief  공통적인 OSX의 입력기 구조를 다룬다.
-
- InputManager는 @ref InputController 또는 테스트코드에 해당하는 외부에서 입력을 받아 입력기에서 처리 후 결과 값을 보관한다. 처리 후 그 결과를 확인하는 것은 사용자의 몫이다.
-
- IMKServer나 클라이언트와 무관하게 입력 값에 대해 출력 값을 생성해 내는 입력기. 입력 뿐만 아니라 여러 키보드 간 전환이나 입력기에 관한 단축키 등 입력기에 관한 모든 기능을 다룬다.
-
- @coclass    IMKServer DelegatedComposer
- */
+//! @brief  공통적인 OSX의 입력기 구조를 다룬다.
+//!
+//! InputManager는 @ref InputController 또는 테스트코드에 해당하는 외부에서 입력을 받아 입력기에서 처리 후 결과 값을 보관한다. 처리 후 그 결과를 확인하는 것은 사용자의 몫이다.
+//!
+//! IMKServer나 클라이언트와 무관하게 입력 값에 대해 출력 값을 생성해 내는 입력기. 입력 뿐만 아니라 여러 키보드 간 전환이나 입력기에 관한 단축키 등 입력기에 관한 모든 기능을 다룬다.
+//!
+//! @coclass    IMKServer DelegatedComposer
 // TODO: InputTextDelegate를 제거하고 서버만 관리하도록 한다
 public class InputMethodServer {
-    public static let shared = InputMethodServer()
-    //! @brief  현재 입력중인 서버
-    let server: IMKServer
-    //! @property
-    let candidates: IMKCandidates
-    //! @brief  입력기가 inputText: 문맥에 있는지 여부를 저장
-    let io: IOKitty
+  public static let shared = InputMethodServer()
+  //! @brief  현재 입력중인 서버
+  let server: IMKServer
+  //! @property
+  let candidates: IMKCandidates
+  //! @brief  입력기가 inputText: 문맥에 있는지 여부를 저장
+  let io: IOKitty
 
-    convenience init() {
-        let bundle = Bundle.main
-        var name = bundle.infoDictionary!["InputMethodConnectionName"] as! String
-        #if DEBUG
-            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
-                name += "_Test" + String(describing: Int.random(in: 0 ..< 0x10000))
-            } else {
-                name += "_Debug"
-            }
-        #endif
+  convenience init() {
+    let bundle = Bundle.main
+    var name = bundle.infoDictionary!["InputMethodConnectionName"] as! String
+    #if DEBUG
+      if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+        name += "_Test" + String(describing: Int.random(in: 0..<0x10000))
+      } else {
+        name += "_Debug"
+      }
+    #endif
 
-        self.init(name: name)
+    self.init(name: name)
+  }
+
+  init(name: String) {
+    dlog(debugInputServer, "** InputMethodServer Init")
+
+    server = IMKServer(name: name, bundleIdentifier: Bundle.main.bundleIdentifier)
+    candidates = IMKCandidates(server: server, panelType: kIMKSingleColumnScrollingCandidatePanel)
+    // candidates.setSelectionKeysKeylayout(TISInputSource.currentKeyboardLayout())
+
+    io = IOKitty()!
+    dlog(debugInputServer, "\t%@", description)
+  }
+
+  var description: String {
+    return """
+      <InputMethodServer server: "\(String(describing: server))" candidates: "\(String(describing: candidates))">
+      """
+  }
+
+  func showOrHideCandidates(controller: InputController) {
+    showOrHideCandidates(composer: controller.receiver.composer)
+  }
+
+  func showOrHideCandidates(composer: Composer) {
+    if composer.hasCandidates {
+      candidates.update()
+      candidates.show(kIMKLocateCandidatesLeftHint)
+    } else if candidates.isVisible() {
+      candidates.hide()
     }
-
-    init(name: String) {
-        dlog(DEBUG_INPUT_SERVER, "** InputMethodServer Init")
-
-        server = IMKServer(name: name, bundleIdentifier: Bundle.main.bundleIdentifier)
-        candidates = IMKCandidates(server: server, panelType: kIMKSingleColumnScrollingCandidatePanel)
-        // candidates.setSelectionKeysKeylayout(TISInputSource.currentKeyboardLayout())
-
-        io = IOKitty()!
-        dlog(DEBUG_INPUT_SERVER, "\t%@", description)
-    }
-
-    var description: String {
-        return """
-        <InputMethodServer server: "\(String(describing: server))" candidates: "\(String(describing: candidates))">
-        """
-    }
-
-    func showOrHideCandidates(controller: InputController) {
-        showOrHideCandidates(composer: controller.receiver.composer)
-    }
-
-    func showOrHideCandidates(composer: Composer) {
-        if composer.hasCandidates {
-            candidates.update()
-            candidates.show(kIMKLocateCandidatesLeftHint)
-        } else if candidates.isVisible() {
-            candidates.hide()
-        }
-    }
+  }
 }

--- a/OSXCore/InputReceiver.swift
+++ b/OSXCore/InputReceiver.swift
@@ -9,256 +9,283 @@
 import Foundation
 import InputMethodKit
 
-let DEBUG_INPUT_RECEIVER = false
+let debugInputReceiver = false
 
 public class InputReceiver: InputTextDelegate {
-    var inputClient: IMKTextInput & IMKUnicodeTextInput
-    var composer = GureumComposer()
-    weak var controller: InputController!
-    var inputting: Bool = false
-    var hasSelectionRange: Bool = false
+  var inputClient: IMKTextInput & IMKUnicodeTextInput
+  var composer = GureumComposer()
+  weak var controller: InputController!
+  var inputting: Bool = false
+  var hasSelectionRange: Bool = false
 
-    init(server: IMKServer, delegate: Any!, client: IMKTextInput & IMKUnicodeTextInput, controller: InputController) {
-        dlog(DEBUG_INPUT_RECEIVER, "**** NEW INPUT CONTROLLER INIT **** WITH SERVER: %@ / DELEGATE: %@ / CLIENT: %@", server, (delegate as? NSObject) ?? "(nil)", (client as? NSObject) ?? "(nil)")
-        inputClient = client
-        self.controller = controller
+  init(
+    server: IMKServer, delegate: Any!, client: IMKTextInput & IMKUnicodeTextInput,
+    controller: InputController
+  ) {
+    dlog(
+      debugInputReceiver,
+      "**** NEW INPUT CONTROLLER INIT **** WITH SERVER: %@ / DELEGATE: %@ / CLIENT: %@", server,
+      (delegate as? NSObject) ?? "(nil)", (client as? NSObject) ?? "(nil)")
+    inputClient = client
+    self.controller = controller
+  }
+
+  // MARK: - IMKServerInputTextData
+
+  func input2(
+    text string: String?, keyCode: KeyCode, modifiers flags: NSEvent.ModifierFlags,
+    client sender: IMKTextInput & IMKUnicodeTextInput
+  ) -> InputResult {
+    // 특정 애플리케이션에서 커맨드/옵션/컨트롤 키 입력을 선점하지 못하는 문제를 회피한다
+    if flags.contains(.command) || flags.contains(.control) {
+      dlog(
+        debugInputReceiver, "-- InputReceiver -inputText: Command/Control key input / returned NO"
+      )
+      return InputResult(processed: false, action: .commit)
     }
 
-    // MARK: - IMKServerInputTextData
+    if string == nil, !flags.contains(.option) {
+      return InputResult(processed: false, action: .commit)
+    }
 
-    func input2(text string: String?, keyCode: KeyCode, modifiers flags: NSEvent.ModifierFlags, client sender: IMKTextInput & IMKUnicodeTextInput) -> InputResult {
-        // 특정 애플리케이션에서 커맨드/옵션/컨트롤 키 입력을 선점하지 못하는 문제를 회피한다
-        if flags.contains(.command) || flags.contains(.control) {
-            dlog(DEBUG_INPUT_RECEIVER, "-- InputReceiver -inputText: Command/Control key input / returned NO")
-            return InputResult(processed: false, action: .commit)
-        }
+    let result = composer.input(text: string, key: keyCode, modifiers: flags, client: sender)
 
-        if string == nil, !flags.contains(.option) {
-            return InputResult(processed: false, action: .commit)
-        }
+    return result
+  }
 
-        let result = composer.input(text: string, key: keyCode, modifiers: flags, client: sender)
+  // MARK: InputTextDelegate 프로토콜 구현
 
+  // IMKServerInput 프로토콜에 대한 공용 핸들러
+  func input(
+    text string: String?,
+    key keyCode: KeyCode,
+    modifiers flags: NSEvent.ModifierFlags,
+    client sender: IMKTextInput & IMKUnicodeTextInput
+  ) -> InputResult {
+    let selected = sender.selectedRange()
+    let marked = sender.markedRange()
+    if selected.location != marked.location {
+      //            dlog(debugLogging, "MISMATCHING: \(selected) \(marked)")
+      //            cancelComposition()
+      //            sender.setMarkedText("", selectionRange: NSRange(location: 0, length: 0), replacementRange: NSRange(location: selected.location, length: 0))
+      //
+      //            // commitComposition(sender)
+      //            marked = selected
+    }
+
+    // 입력기용 특수 커맨드 처리
+    if let command = composer.filterCommand(keyCode: keyCode, modifiers: flags, client: sender) {
+      let result = input(event: command, client: sender)
+      if result.processed {
         return result
+      }
     }
 
-    // MARK: InputTextDelegate 프로토콜 구현
+    dlog(
+      debugLogging, "LOGGING::KEY::(%@)(%ld)(%lu)",
+      string?.replacingOccurrences(of: "\n", with: "\\n") ?? "(nil)", keyCode.rawValue,
+      flags.rawValue)
 
-    // IMKServerInput 프로토콜에 대한 공용 핸들러
-    func input(text string: String?,
-               key keyCode: KeyCode,
-               modifiers flags: NSEvent.ModifierFlags,
-               client sender: IMKTextInput & IMKUnicodeTextInput) -> InputResult
+    let hadComposedString = !_internalComposedString.isEmpty
+    let result = input2(text: string, keyCode: keyCode, modifiers: flags, client: sender)
+
+    // 합성 후보가 있다면 보여준다
+    InputMethodServer.shared.showOrHideCandidates(controller: controller)
+
+    inputting = true
+
+    if result.action != .none {
+      cancelComposition()
+    }
+
+    let commited = commitCompositionEvent(sender)  // 조합 된 문자 반영
+    if result.action == .commit {
+      return result
+    }
+    let hasComposedString = !_internalComposedString.isEmpty
+    let selectionRange = controller.selectionRange()
+    hasSelectionRange = selectionRange.location != NSNotFound && selectionRange.length > 0
+    if commited || controller.selectionRange().length > 0 || hadComposedString || hasComposedString
     {
-        let selected = sender.selectedRange()
-        let marked = sender.markedRange()
-        if selected.location != marked.location {
-//            dlog(DEBUG_LOGGING, "MISMATCHING: \(selected) \(marked)")
-//            cancelComposition()
-//            sender.setMarkedText("", selectionRange: NSRange(location: 0, length: 0), replacementRange: NSRange(location: selected.location, length: 0))
-//
-//            // commitComposition(sender)
-//            marked = selected
-        }
-
-        // 입력기용 특수 커맨드 처리
-        if let command = composer.filterCommand(keyCode: keyCode, modifiers: flags, client: sender) {
-            let result = input(event: command, client: sender)
-            if result.processed {
-                return result
-            }
-        }
-
-        dlog(DEBUG_LOGGING, "LOGGING::KEY::(%@)(%ld)(%lu)", string?.replacingOccurrences(of: "\n", with: "\\n") ?? "(nil)", keyCode.rawValue, flags.rawValue)
-
-        let hadComposedString = !_internalComposedString.isEmpty
-        let result = input2(text: string, keyCode: keyCode, modifiers: flags, client: sender)
-
-        // 합성 후보가 있다면 보여준다
-        InputMethodServer.shared.showOrHideCandidates(controller: controller)
-
-        inputting = true
-
-        if result.action != .none {
-            cancelComposition()
-        }
-
-        let commited = commitCompositionEvent(sender) // 조합 된 문자 반영
-        if result.action == .commit {
-            return result
-        }
-        let hasComposedString = !_internalComposedString.isEmpty
-        let selectionRange = controller.selectionRange()
-        hasSelectionRange = selectionRange.location != NSNotFound && selectionRange.length > 0
-        if commited || controller.selectionRange().length > 0 || hadComposedString || hasComposedString {
-            updateComposition() // 조합 중인 문자 반영
-        }
-
-        inputting = false
-
-        dlog(DEBUG_INPUT_RECEIVER, "*** End of Input handling ***")
-        return result
+      updateComposition()  // 조합 중인 문자 반영
     }
 
-    func input(event: InputEvent, client sender: IMKTextInput & IMKUnicodeTextInput) -> InputResult {
-        switch event {
-        case let .changeLayout(layout, processed):
-            let innerLayout = layout == .toggleByCapsLock || layout == .toggleByRightKey ? .toggle : layout
-            let result = composer.changeLayout(innerLayout, client: sender)
-            // 합성 후보가 있다면 보여준다
-            InputMethodServer.shared.showOrHideCandidates(controller: controller)
+    inputting = false
 
-            inputting = true
+    dlog(debugInputReceiver, "*** End of Input handling ***")
+    return result
+  }
 
-            if result.action != .none {
-                cancelComposition()
-                if result.action != .cancel {
-                    commitCompositionEvent(sender)
-                    if case let .layout(mode) = result.action, layout != .toggleByCapsLock {
-                        (sender as IMKTextInput).selectMode(mode)
-                    }
-                } else {
-                    updateComposition() // 조합 중인 문자 반영
-                }
-            }
+  func input(event: InputEvent, client sender: IMKTextInput & IMKUnicodeTextInput) -> InputResult {
+    switch event {
+    case .changeLayout(let layout, let processed):
+      let innerLayout =
+        layout == .toggleByCapsLock || layout == .toggleByRightKey ? .toggle : layout
+      let result = composer.changeLayout(innerLayout, client: sender)
+      // 합성 후보가 있다면 보여준다
+      InputMethodServer.shared.showOrHideCandidates(controller: controller)
 
-            inputting = false
+      inputting = true
 
-            return processed ? .processed : .notProcessed
+      if result.action != .none {
+        cancelComposition()
+        if result.action != .cancel {
+          commitCompositionEvent(sender)
+          if case .layout(let mode) = result.action, layout != .toggleByCapsLock {
+            (sender as IMKTextInput).selectMode(mode)
+          }
+        } else {
+          updateComposition()  // 조합 중인 문자 반영
         }
+      }
+
+      inputting = false
+
+      return processed ? .processed : .notProcessed
     }
+  }
 }
 
-extension InputReceiver { // IMKServerInput
-    // Committing a Composition
-    // 조합을 중단하고 현재까지 조합된 글자를 커밋한다.
-    func commitComposition(_ sender: IMKTextInput & IMKUnicodeTextInput) {
-        dlog(DEBUG_LOGGING, "LOGGING::EVENT::COMMIT-INTERNAL")
-        commitCompositionEvent(sender)
+extension InputReceiver {  // IMKServerInput
+  // Committing a Composition
+  // 조합을 중단하고 현재까지 조합된 글자를 커밋한다.
+  func commitComposition(_ sender: IMKTextInput & IMKUnicodeTextInput) {
+    dlog(debugLogging, "LOGGING::EVENT::COMMIT-INTERNAL")
+    commitCompositionEvent(sender)
+  }
+
+  func updateComposition() {
+    dlog(debugLogging, "LOGGING::EVENT::UPDATE-INTERNAL")
+    controller.updateComposition()
+  }
+
+  func cancelComposition() {
+    dlog(debugLogging, "LOGGING::EVENT::CANCEL-INTERNAL")
+    controller.cancelComposition()
+  }
+
+  // Committing a Composition
+  // 조합을 중단하고 현재까지 조합된 글자를 커밋한다.
+  @discardableResult
+  func commitCompositionEvent(_ sender: IMKTextInput & IMKUnicodeTextInput) -> Bool {
+    dlog(debugLogging, "LOGGING::EVENT::COMMIT")
+    if !inputting {
+      // 입력기 외부에서 들어오는 커밋 요청에 대해서는 편집 중인 글자도 커밋한다.
+      dlog(
+        debugInputController, "-- CANCEL composition because of external commit request from %@",
+        sender as! NSObject)
+      dlog(debugLogging, "LOGGING::EVENT::CANCEL-INTERNAL")
+      cancelCompositionEvent()
+    }
+    // 왠지는 모르겠지만 프로그램마다 동작이 달라서 조합을 반드시 마쳐주어야 한다
+    // 터미널과 같이 조합중에 리턴키 먹는 프로그램은 조합 중인 문자가 없고 보통은 있다
+    let commitString = composer.dequeueCommitString()
+
+    // 커밋할 문자가 없으면 중단
+    if commitString.isEmpty {
+      return false
     }
 
-    func updateComposition() {
-        dlog(DEBUG_LOGGING, "LOGGING::EVENT::UPDATE-INTERNAL")
-        controller.updateComposition()
+    dlog(
+      debugInputReceiver, "** InputController -commitComposition: with sender: %@ / strings: %@",
+      sender as! NSObject, commitString)
+    var range = controller.selectionRange()
+    dlog(debugLogging, "LOGGING::COMMIT::%lu:%lu:%@", range.location, range.length, commitString)
+    // NSLog("range1 \(range)")글
+    if range.length == 0 {
+      range = NSRange(location: NSNotFound, length: 0)
     }
+    // NSLog("commit \(commitString) to \(range)")
+    controller.client().insertText(commitString, replacementRange: range)
 
-    func cancelComposition() {
-        dlog(DEBUG_LOGGING, "LOGGING::EVENT::CANCEL-INTERNAL")
-        controller.cancelComposition()
-    }
+    InputMethodServer.shared.showOrHideCandidates(controller: controller)
 
-    // Committing a Composition
-    // 조합을 중단하고 현재까지 조합된 글자를 커밋한다.
-    @discardableResult
-    func commitCompositionEvent(_ sender: IMKTextInput & IMKUnicodeTextInput) -> Bool {
-        dlog(DEBUG_LOGGING, "LOGGING::EVENT::COMMIT")
-        if !inputting {
-            // 입력기 외부에서 들어오는 커밋 요청에 대해서는 편집 중인 글자도 커밋한다.
-            dlog(DEBUG_INPUTCONTROLLER, "-- CANCEL composition because of external commit request from %@", sender as! NSObject)
-            dlog(DEBUG_LOGGING, "LOGGING::EVENT::CANCEL-INTERNAL")
-            cancelCompositionEvent()
-        }
-        // 왠지는 모르겠지만 프로그램마다 동작이 달라서 조합을 반드시 마쳐주어야 한다
-        // 터미널과 같이 조합중에 리턴키 먹는 프로그램은 조합 중인 문자가 없고 보통은 있다
-        let commitString = composer.dequeueCommitString()
+    return true
+  }
 
-        // 커밋할 문자가 없으면 중단
-        if commitString.isEmpty {
-            return false
-        }
+  func updateCompositionEvent() {
+    dlog(debugLogging, "LOGGING::EVENT::UPDATE")
+    dlog(debugInputController, "** InputController -updateComposition")
+  }
 
-        dlog(DEBUG_INPUT_RECEIVER, "** InputController -commitComposition: with sender: %@ / strings: %@", sender as! NSObject, commitString)
-        var range = controller.selectionRange()
-        dlog(DEBUG_LOGGING, "LOGGING::COMMIT::%lu:%lu:%@", range.location, range.length, commitString)
-        // NSLog("range1 \(range)")글
-        if range.length == 0 {
-            range = NSRange(location: NSNotFound, length: 0)
-        }
-        // NSLog("commit \(commitString) to \(range)")
-        controller.client().insertText(commitString, replacementRange: range)
+  func cancelCompositionEvent() {
+    dlog(debugLogging, "LOGGING::EVENT::CANCEL")
+    composer.cancelComposition()
+  }
 
-        InputMethodServer.shared.showOrHideCandidates(controller: controller)
+  var _internalComposedString: String {
+    return composer.composedString
+  }
 
-        return true
-    }
+  // Getting Input Strings and Candidates
+  // 현재 입력 중인 글자를 반환한다. -updateComposition: 이 사용
+  func composedString(_: IMKTextInput & IMKUnicodeTextInput) -> String {
+    let string = _internalComposedString
+    dlog(debugLogging, "LOGGING::CHECK::COMPOSEDSTRING::(%@)", string)
+    dlog(debugInputController, "** InputController -composedString: with return: '%@'", string)
+    return string
+  }
 
-    func updateCompositionEvent() {
-        dlog(DEBUG_LOGGING, "LOGGING::EVENT::UPDATE")
-        dlog(DEBUG_INPUTCONTROLLER, "** InputController -updateComposition")
-    }
+  func originalString(_: IMKTextInput & IMKUnicodeTextInput) -> NSAttributedString {
+    dlog(debugInputController, "** InputController -originalString:")
+    let s = NSAttributedString(string: composer.originalString)
+    dlog(debugLogging, "LOGGING::CHECK::ORIGINALSTRING::%@", s.string)
+    return s
+  }
 
-    func cancelCompositionEvent() {
-        dlog(DEBUG_LOGGING, "LOGGING::EVENT::CANCEL")
-        composer.cancelComposition()
-    }
+  func candidates(_: IMKTextInput & IMKUnicodeTextInput) -> [Any]! {
+    dlog(debugLogging, "LOGGING::CHECK::CANDIDATES")
+    return composer.candidates
+  }
 
-    var _internalComposedString: String {
-        return composer.composedString
-    }
+  func candidateSelected(_ candidateString: NSAttributedString) {
+    dlog(debugLogging, "LOGGING::CHECK::CANDIDATESELECTED::%@", candidateString)
+    inputting = true
+    composer.candidateSelected(candidateString)
+    commitCompositionEvent(inputClient)
+    inputting = false
+  }
 
-    // Getting Input Strings and Candidates
-    // 현재 입력 중인 글자를 반환한다. -updateComposition: 이 사용
-    func composedString(_: IMKTextInput & IMKUnicodeTextInput) -> String {
-        let string = _internalComposedString
-        dlog(DEBUG_LOGGING, "LOGGING::CHECK::COMPOSEDSTRING::(%@)", string)
-        dlog(DEBUG_INPUTCONTROLLER, "** InputController -composedString: with return: '%@'", string)
-        return string
-    }
-
-    func originalString(_: IMKTextInput & IMKUnicodeTextInput) -> NSAttributedString {
-        dlog(DEBUG_INPUTCONTROLLER, "** InputController -originalString:")
-        let s = NSAttributedString(string: composer.originalString)
-        dlog(DEBUG_LOGGING, "LOGGING::CHECK::ORIGINALSTRING::%@", s.string)
-        return s
-    }
-
-    func candidates(_: IMKTextInput & IMKUnicodeTextInput) -> [Any]! {
-        dlog(DEBUG_LOGGING, "LOGGING::CHECK::CANDIDATES")
-        return composer.candidates
-    }
-
-    func candidateSelected(_ candidateString: NSAttributedString) {
-        dlog(DEBUG_LOGGING, "LOGGING::CHECK::CANDIDATESELECTED::%@", candidateString)
-        inputting = true
-        composer.candidateSelected(candidateString)
-        commitCompositionEvent(inputClient)
-        inputting = false
-    }
-
-    func candidateSelectionChanged(_ candidateString: NSAttributedString) {
-        dlog(DEBUG_LOGGING, "LOGGING::CHECK::CANDIDATESELECTIONCHANGED::%@", candidateString)
-        composer.candidateSelectionChanged(candidateString)
-        updateComposition()
-    }
+  func candidateSelectionChanged(_ candidateString: NSAttributedString) {
+    dlog(debugLogging, "LOGGING::CHECK::CANDIDATESELECTIONCHANGED::%@", candidateString)
+    composer.candidateSelectionChanged(candidateString)
+    updateComposition()
+  }
 }
 
-extension InputReceiver { // IMKStateSetting
-    //! @brief  마우스 이벤트를 잡을 수 있게 한다.
-    func recognizedEvents(_: IMKTextInput & IMKUnicodeTextInput) -> NSEvent.EventTypeMask {
-        dlog(DEBUG_LOGGING, "LOGGING::CHECK::RECOGNIZEDEVENTS")
-        // NSFlagsChangeMask는 -handleEvent: 에서만 동작
-        return NSEvent.EventTypeMask(arrayLiteral: .keyDown, .flagsChanged, .leftMouseUp, .rightMouseUp, .leftMouseDown, .rightMouseDown, .leftMouseDragged, .rightMouseDragged, .appKitDefined, .applicationDefined, .systemDefined)
-    }
+extension InputReceiver {  // IMKStateSetting
+  //! @brief  마우스 이벤트를 잡을 수 있게 한다.
+  func recognizedEvents(_: IMKTextInput & IMKUnicodeTextInput) -> NSEvent.EventTypeMask {
+    dlog(debugLogging, "LOGGING::CHECK::RECOGNIZEDEVENTS")
+    // NSFlagsChangeMask는 -handleEvent: 에서만 동작
+    return NSEvent.EventTypeMask(
+      arrayLiteral: .keyDown, .flagsChanged, .leftMouseUp, .rightMouseUp, .leftMouseDown,
+      .rightMouseDown, .leftMouseDragged, .rightMouseDragged, .appKitDefined, .applicationDefined,
+      .systemDefined)
+  }
 
-    //! @brief 자판 전환을 감지한다.
-    func setValue(_ value: Any, forTag tag: Int, client sender: IMKTextInput & IMKUnicodeTextInput) {
-        InputMethodServer.shared.io.capsLockDate = nil
-        dlog(DEBUG_LOGGING, "LOGGING::EVENT::CHANGE-%lu-%@", tag, value as? String ?? "(nonstring)")
-        dlog(DEBUG_INPUTCONTROLLER, "** InputController -setValue:forTag:client: with value: %@ / tag: %lx / client: %@", value as? String ?? "(nonstring)", tag, String(describing: controller.client as AnyObject))
-        sender.overrideKeyboard(withKeyboardNamed: Configuration.shared.overridingKeyboardName)
-        switch tag {
-        case kTextServiceInputModePropertyTag:
-            guard let value = value as? String else {
-                NSLog("Failed to change keyboard layout")
-                assertionFailure()
-                break
-            }
-            if value != composer.inputMode {
-                commitComposition(sender)
-                composer.inputMode = value
-            }
-        default:
-            dlog(true, "**** UNKNOWN TAG %ld !!! ****", tag)
-        }
+  //! @brief 자판 전환을 감지한다.
+  func setValue(_ value: Any, forTag tag: Int, client sender: IMKTextInput & IMKUnicodeTextInput) {
+    InputMethodServer.shared.io.capsLockDate = nil
+    dlog(debugLogging, "LOGGING::EVENT::CHANGE-%lu-%@", tag, value as? String ?? "(nonstring)")
+    dlog(
+      debugInputController,
+      "** InputController -setValue:forTag:client: with value: %@ / tag: %lx / client: %@",
+      value as? String ?? "(nonstring)", tag, String(describing: controller.client as AnyObject))
+    sender.overrideKeyboard(withKeyboardNamed: Configuration.shared.overridingKeyboardName)
+    switch tag {
+    case kTextServiceInputModePropertyTag:
+      guard let value = value as? String else {
+        NSLog("Failed to change keyboard layout")
+        assertionFailure()
+        break
+      }
+      if value != composer.inputMode {
+        commitComposition(sender)
+        composer.inputMode = value
+      }
+    default:
+      dlog(true, "**** UNKNOWN TAG %ld !!! ****", tag)
     }
+  }
 }

--- a/OSXCore/KeyCode.swift
+++ b/OSXCore/KeyCode.swift
@@ -10,195 +10,195 @@ import Cocoa
 
 /// 키보드 레이아웃과 독립적인 키에 대한 키 코드를 정의한 열거형.
 public enum KeyCode: Int {
-    // MARK: ANSI-standard US keyboard
+  // MARK: ANSI-standard US keyboard
 
-    case ansiA = 0x00
-    case ansiS = 0x01
-    case ansiD = 0x02
-    case ansiF = 0x03
-    case ansiH = 0x04
-    case ansiG = 0x05
-    case ansiZ = 0x06
-    case ansiX = 0x07
-    case ansiC = 0x08
-    case ansiV = 0x09
-    case ansiB = 0x0B
-    case ansiQ = 0x0C
-    case ansiW = 0x0D
-    case ansiE = 0x0E
-    case ansiR = 0x0F
-    case ansiY = 0x10
-    case ansiT = 0x11
-    case ansi1 = 0x12
-    case ansi2 = 0x13
-    case ansi3 = 0x14
-    case ansi4 = 0x15
-    case ansi6 = 0x16
-    case ansi5 = 0x17
-    case ansiEqual = 0x18
-    case ansi9 = 0x19
-    case ansi7 = 0x1A
-    case ansiMinus = 0x1B
-    case ansi8 = 0x1C
-    case ansi0 = 0x1D
-    case ansiRightBracket = 0x1E
-    case ansiO = 0x1F
-    case ansiU = 0x20
-    case ansiLeftBracket = 0x21
-    case ansiI = 0x22
-    case ansiP = 0x23
-    case ansiL = 0x25
-    case ansiJ = 0x26
-    case ansiQuote = 0x27
-    case ansiK = 0x28
-    case ansiSemicolon = 0x29
-    case ansiBackslash = 0x2A
-    case ansiComma = 0x2B
-    case ansiSlash = 0x2C
-    case ansiN = 0x2D
-    case ansiM = 0x2E
-    case ansiPeriod = 0x2F
-    case ansiGrave = 0x32
-    case ansiKeypadDecimal = 0x41
-    case ansiKeypadMultiply = 0x43
-    case ansiKeypadPlus = 0x45
-    case ansiKeypadClear = 0x47
-    case ansiKeypadDivide = 0x4B
-    case ansiKeypadEnter = 0x4C
-    case ansiKeypadMinus = 0x4E
-    case ansiKeypadEquals = 0x51
-    case ansiKeypad0 = 0x52
-    case ansiKeypad1 = 0x53
-    case ansiKeypad2 = 0x54
-    case ansiKeypad3 = 0x55
-    case ansiKeypad4 = 0x56
-    case ansiKeypad5 = 0x57
-    case ansiKeypad6 = 0x58
-    case ansiKeypad7 = 0x59
-    case ansiKeypad8 = 0x5B
-    case ansiKeypad9 = 0x5C
+  case ansiA = 0x00
+  case ansiS = 0x01
+  case ansiD = 0x02
+  case ansiF = 0x03
+  case ansiH = 0x04
+  case ansiG = 0x05
+  case ansiZ = 0x06
+  case ansiX = 0x07
+  case ansiC = 0x08
+  case ansiV = 0x09
+  case ansiB = 0x0B
+  case ansiQ = 0x0C
+  case ansiW = 0x0D
+  case ansiE = 0x0E
+  case ansiR = 0x0F
+  case ansiY = 0x10
+  case ansiT = 0x11
+  case ansi1 = 0x12
+  case ansi2 = 0x13
+  case ansi3 = 0x14
+  case ansi4 = 0x15
+  case ansi6 = 0x16
+  case ansi5 = 0x17
+  case ansiEqual = 0x18
+  case ansi9 = 0x19
+  case ansi7 = 0x1A
+  case ansiMinus = 0x1B
+  case ansi8 = 0x1C
+  case ansi0 = 0x1D
+  case ansiRightBracket = 0x1E
+  case ansiO = 0x1F
+  case ansiU = 0x20
+  case ansiLeftBracket = 0x21
+  case ansiI = 0x22
+  case ansiP = 0x23
+  case ansiL = 0x25
+  case ansiJ = 0x26
+  case ansiQuote = 0x27
+  case ansiK = 0x28
+  case ansiSemicolon = 0x29
+  case ansiBackslash = 0x2A
+  case ansiComma = 0x2B
+  case ansiSlash = 0x2C
+  case ansiN = 0x2D
+  case ansiM = 0x2E
+  case ansiPeriod = 0x2F
+  case ansiGrave = 0x32
+  case ansiKeypadDecimal = 0x41
+  case ansiKeypadMultiply = 0x43
+  case ansiKeypadPlus = 0x45
+  case ansiKeypadClear = 0x47
+  case ansiKeypadDivide = 0x4B
+  case ansiKeypadEnter = 0x4C
+  case ansiKeypadMinus = 0x4E
+  case ansiKeypadEquals = 0x51
+  case ansiKeypad0 = 0x52
+  case ansiKeypad1 = 0x53
+  case ansiKeypad2 = 0x54
+  case ansiKeypad3 = 0x55
+  case ansiKeypad4 = 0x56
+  case ansiKeypad5 = 0x57
+  case ansiKeypad6 = 0x58
+  case ansiKeypad7 = 0x59
+  case ansiKeypad8 = 0x5B
+  case ansiKeypad9 = 0x5C
 
-    // MARK: Keycodes for keys that are independent of keyboard layout
+  // MARK: Keycodes for keys that are independent of keyboard layout
 
-    case `return` = 0x24
-    case tab = 0x30
-    case space = 0x31
-    case delete = 0x33
-    case escape = 0x35
-    case command = 0x37
-    case shift = 0x38
-    case capsLock = 0x39
-    case option = 0x3A
-    case control = 0x3B
-    case rightCommand = 0x36
-    case rightShift = 0x3C
-    case rightOption = 0x3D
-    case rightControl = 0x3E
-    case function = 0x3F
-    case f17 = 0x40
-    case volumeUp = 0x48
-    case volumeDown = 0x49
-    case mute = 0x4A
-    case f18 = 0x4F
-    case f19 = 0x50
-    case f20 = 0x5A
-    case f5 = 0x60
-    case f6 = 0x61
-    case f7 = 0x62
-    case f3 = 0x63
-    case f8 = 0x64
-    case f9 = 0x65
-    case f11 = 0x67
-    case f13 = 0x69
-    case f16 = 0x6A
-    case f14 = 0x6B
-    case f10 = 0x6D
-    case f12 = 0x6F
-    case f15 = 0x71
-    case help = 0x72
-    case home = 0x73
-    case pageUp = 0x74
-    case forwardDelete = 0x75
-    case f4 = 0x76
-    case end = 0x77
-    case f2 = 0x78
-    case pageDown = 0x79
-    case f1 = 0x7A
-    case leftArrow = 0x7B
-    case rightArrow = 0x7C
-    case downArrow = 0x7D
-    case upArrow = 0x7E
+  case `return` = 0x24
+  case tab = 0x30
+  case space = 0x31
+  case delete = 0x33
+  case escape = 0x35
+  case command = 0x37
+  case shift = 0x38
+  case capsLock = 0x39
+  case option = 0x3A
+  case control = 0x3B
+  case rightCommand = 0x36
+  case rightShift = 0x3C
+  case rightOption = 0x3D
+  case rightControl = 0x3E
+  case function = 0x3F
+  case f17 = 0x40
+  case volumeUp = 0x48
+  case volumeDown = 0x49
+  case mute = 0x4A
+  case f18 = 0x4F
+  case f19 = 0x50
+  case f20 = 0x5A
+  case f5 = 0x60
+  case f6 = 0x61
+  case f7 = 0x62
+  case f3 = 0x63
+  case f8 = 0x64
+  case f9 = 0x65
+  case f11 = 0x67
+  case f13 = 0x69
+  case f16 = 0x6A
+  case f14 = 0x6B
+  case f10 = 0x6D
+  case f12 = 0x6F
+  case f15 = 0x71
+  case help = 0x72
+  case home = 0x73
+  case pageUp = 0x74
+  case forwardDelete = 0x75
+  case f4 = 0x76
+  case end = 0x77
+  case f2 = 0x78
+  case pageDown = 0x79
+  case f1 = 0x7A
+  case leftArrow = 0x7B
+  case rightArrow = 0x7C
+  case downArrow = 0x7D
+  case upArrow = 0x7E
 
-    // MARK: ISO keyboards only
+  // MARK: ISO keyboards only
 
-    case isoSection = 0x0A
+  case isoSection = 0x0A
 
-    // MARK: JIS keyboards only
+  // MARK: JIS keyboards only
 
-    case jisYen = 0x5D
-    case jisUnderscore = 0x5E
-    case jisKeypadComma = 0x5F
-    case jisEisu = 0x66
-    case jisKana = 0x68
+  case jisYen = 0x5D
+  case jisUnderscore = 0x5E
+  case jisKeypadComma = 0x5F
+  case jisEisu = 0x66
+  case jisKana = 0x68
 }
 
-public extension KeyCode {
-    /// 구름 입력기의 키와 매핑 가능한지를 나타낸다.
-    ///
-    /// `KeyMapLower` 및 `KeyMapUpper`에 정의된 문자와 매핑될 수 있는지를 나타낸다.
-    /// 일반적인 키보드 상에서 영문자, 숫자, 리턴, 탭, 스페이스, 역따옴표가 위치해 있는 키를 포함한다.
-    var isKeyMappable: Bool {
-        return self <= .ansiGrave
-    }
+extension KeyCode {
+  /// 구름 입력기의 키와 매핑 가능한지를 나타낸다.
+  ///
+  /// `keyMapLower` 및 `keyMapUpper`에 정의된 문자와 매핑될 수 있는지를 나타낸다.
+  /// 일반적인 키보드 상에서 영문자, 숫자, 리턴, 탭, 스페이스, 역따옴표가 위치해 있는 키를 포함한다.
+  public var isKeyMappable: Bool {
+    return self <= .ansiGrave
+  }
 
-    /// 방향키 위치에 있는 키들을 반환한다.
-    ///
-    /// `.upArrow`, `.downArrow`, `.leftArrow`, `.rightArrow` 케이스를 포함하는 키 코드 배열을 나타낸다.
-    static let arrows: [KeyCode] = [.upArrow, .downArrow, .leftArrow, .rightArrow]
+  /// 방향키 위치에 있는 키들을 반환한다.
+  ///
+  /// `.upArrow`, `.downArrow`, `.leftArrow`, `.rightArrow` 케이스를 포함하는 키 코드 배열을 나타낸다.
+  public static let arrows: [KeyCode] = [.upArrow, .downArrow, .leftArrow, .rightArrow]
 }
 
 // MARK: - Comparable 프로토콜 준수
 
 extension KeyCode: Comparable {
-    public static func < (lhs: KeyCode, rhs: KeyCode) -> Bool {
-        return lhs.rawValue < rhs.rawValue
-    }
+  public static func < (lhs: KeyCode, rhs: KeyCode) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+  }
 }
 
-let KeyMapLower = [
-    "a", "s", "d", "f", "h", "g", "z", "x",
-    "c", "v", nil, "b", "q", "w", "e", "r",
-    "y", "t", "1", "2", "3", "4", "6", "5",
-    "=", "9", "7", "-", "8", "0", "]", "o",
-    "u", "[", "i", "p", nil, "l", "j", "'",
-    "k", ";", "\\", ",", "/", "n", "m", ".",
-    nil, nil, "`",
+let keyMapLower = [
+  "a", "s", "d", "f", "h", "g", "z", "x",
+  "c", "v", nil, "b", "q", "w", "e", "r",
+  "y", "t", "1", "2", "3", "4", "6", "5",
+  "=", "9", "7", "-", "8", "0", "]", "o",
+  "u", "[", "i", "p", nil, "l", "j", "'",
+  "k", ";", "\\", ",", "/", "n", "m", ".",
+  nil, nil, "`",
 ]
 // assert(keyMapLower.count == KeyMapSize)
 
-let KeyMapUpper = [
-    "A", "S", "D", "F", "H", "G", "Z", "X",
-    "C", "V", nil, "B", "Q", "W", "E", "R",
-    "Y", "T", "!", "@", "#", "$", "^", "%",
-    "+", "(", "&", "_", "*", ")", "}", "O",
-    "U", "{", "I", "P", nil, "L", "J", "\"",
-    "K", ":", "|", "<", "?", "N", "M", ">",
-    nil, nil, "~",
+let keyMapUpper = [
+  "A", "S", "D", "F", "H", "G", "Z", "X",
+  "C", "V", nil, "B", "Q", "W", "E", "R",
+  "Y", "T", "!", "@", "#", "$", "^", "%",
+  "+", "(", "&", "_", "*", ")", "}", "O",
+  "U", "{", "I", "P", nil, "L", "J", "\"",
+  "K", ":", "|", "<", "?", "N", "M", ">",
+  nil, nil, "~",
 ]
 
-let KeyMapReversed = {
-    var map: [String: (KeyCode, NSEvent.ModifierFlags)] = [:]
-    for (rawValue, key) in KeyMapLower.enumerated() {
-        guard let key = key else {
-            continue
-        }
-        map[key] = (KeyCode(rawValue: rawValue)!, [])
+let keyMapReversed = {
+  var map: [String: (KeyCode, NSEvent.ModifierFlags)] = [:]
+  for (rawValue, key) in keyMapLower.enumerated() {
+    guard let key = key else {
+      continue
     }
-    for (rawValue, key) in KeyMapUpper.enumerated() {
-        guard let key = key else {
-            continue
-        }
-        map[key] = (KeyCode(rawValue: rawValue)!, [.shift])
+    map[key] = (KeyCode(rawValue: rawValue)!, [])
+  }
+  for (rawValue, key) in keyMapUpper.enumerated() {
+    guard let key = key else {
+      continue
     }
-    return map
+    map[key] = (KeyCode(rawValue: rawValue)!, [.shift])
+  }
+  return map
 }()

--- a/OSXCore/RomanComposer.swift
+++ b/OSXCore/RomanComposer.swift
@@ -13,182 +13,190 @@ import InputMethodKit
 // MARK: - Character 구조체 확장
 
 extension Character {
-    /// 문자가 소문자인지 나타낸다.
-    var isLowercaseCharacter: Bool {
-        return self >= "a" && self <= "z"
-    }
+  /// 문자가 소문자인지 나타낸다.
+  var isLowercaseCharacter: Bool {
+    return self >= "a" && self <= "z"
+  }
 }
 
 // MARK: - RomanComposer 클래스
 
 /// 로마자 합성기 오브젝트.
 final class RomanComposer: Composer {
-    /// 로마자 합성기의 종류를 정의한 열거형.
-    ///
-    /// 각 케이스의 원시 값은 그에 대응하는 키보드 식별자를 나타낸다.
-    enum ComposerType: String {
-        /// 시스템 자판.
-        case system
-        /// 쿼티 자판.
-        case qwerty
-        /// 드보락 자판.
-        case dvorak
-        /// 콜맥 자판.
-        case colemak
+  /// 로마자 합성기의 종류를 정의한 열거형.
+  ///
+  /// 각 케이스의 원시 값은 그에 대응하는 키보드 식별자를 나타낸다.
+  enum ComposerType: String {
+    /// 시스템 자판.
+    case system
+    /// 쿼티 자판.
+    case qwerty
+    /// 드보락 자판.
+    case dvorak
+    /// 콜맥 자판.
+    case colemak
 
-        init?(inputMode: String) {
-            guard let keyboardIdentifier = GureumInputSource(rawValue: inputMode)?.keyboardIdentifier else {
-                return nil
-            }
-            self.init(rawValue: keyboardIdentifier)
-        }
-    }
-
-    private var _commitString: String?
-    private var _composerType: RomanComposer.ComposerType
-
-    private let keyMap: [Character: Character]
-
-    init(type: RomanComposer.ComposerType) {
-        _composerType = type
-        keyMap = zip(RomanComposer.ComposerType.qwerty.keyboardData, type.keyboardData)
-            .reduce(into: [:]) { $0[$1.0] = $1.1 }
-    }
-
-    // MARK: Composer 프로토콜 구현
-
-    var composedString: String {
-        return ""
-    }
-
-    var originalString: String {
-        return _commitString ?? ""
-    }
-
-    var commitString: String {
-        return _commitString ?? ""
-    }
-
-    var hasCandidates: Bool {
-        return false
-    }
-
-    var candidates: [NSAttributedString]? {
+    init?(inputMode: String) {
+      guard let keyboardIdentifier = GureumInputSource(rawValue: inputMode)?.keyboardIdentifier
+      else {
         return nil
+      }
+      self.init(rawValue: keyboardIdentifier)
+    }
+  }
+
+  private var _commitString: String?
+  private var _composerType: RomanComposer.ComposerType
+
+  private let keyMap: [Character: Character]
+
+  init(type: RomanComposer.ComposerType) {
+    _composerType = type
+    keyMap = zip(RomanComposer.ComposerType.qwerty.keyboardData, type.keyboardData)
+      .reduce(into: [:]) { $0[$1.0] = $1.1 }
+  }
+
+  // MARK: Composer 프로토콜 구현
+
+  var composedString: String {
+    return ""
+  }
+
+  var originalString: String {
+    return _commitString ?? ""
+  }
+
+  var commitString: String {
+    return _commitString ?? ""
+  }
+
+  var hasCandidates: Bool {
+    return false
+  }
+
+  var candidates: [NSAttributedString]? {
+    return nil
+  }
+
+  func dequeueCommitString() -> String {
+    let dequeued = _commitString
+    _commitString = nil
+    return dequeued ?? ""
+  }
+
+  func cancelComposition() {}
+
+  func clearCompositionContext() {
+    _commitString = nil
+  }
+
+  func map(text: String?, key: KeyCode, modifiers: NSEvent.ModifierFlags) -> Character? {
+    guard let text = text else {
+      return nil
+    }
+    guard !text.isEmpty, key.isKeyMappable, _composerType != .system else {
+      return nil
     }
 
-    func dequeueCommitString() -> String {
-        let dequeued = _commitString
-        _commitString = nil
-        return dequeued ?? ""
+    let character: Character?
+    if modifiers.contains(.shift) {
+      character = keyMapUpper[key.rawValue]?.first ?? text.first!
+    } else {
+      character = keyMapLower[key.rawValue]?.first ?? text.first!
+    }
+    guard let character = character else {
+      return nil
+    }
+    let newCharacter: Character = {
+      if modifiers.contains(.capsLock), character.isLowercaseCharacter {
+        return Character(UnicodeScalar(String(character).unicodeScalars.first!.value - 0x20)!)
+      } else {
+        return character
+      }
+    }()
+    guard let mappedCharacter = keyMap[newCharacter] else {
+      return nil
+    }
+    return mappedCharacter
+  }
+
+  func input(
+    text: String?,
+    key: KeyCode,
+    modifiers: NSEvent.ModifierFlags,
+    client _: IMKTextInput & IMKUnicodeTextInput
+  ) -> InputResult {
+    guard let text = text else {
+      assertionFailure()
+      return .notProcessed
     }
 
-    func cancelComposition() {}
-
-    func clearCompositionContext() {
-        _commitString = nil
+    guard !modifiers.contains(.option) else {
+      _commitString = nil
+      return .notProcessed
     }
 
-    func map(text: String?, key: KeyCode, modifiers: NSEvent.ModifierFlags) -> Character? {
-        guard let text = text else {
-            return nil
-        }
-        guard !text.isEmpty, key.isKeyMappable, _composerType != .system else {
-            return nil
-        }
-
-        let character: Character?
-        if modifiers.contains(.shift) {
-            character = KeyMapUpper[key.rawValue]?.first ?? text.first!
-        } else {
-            character = KeyMapLower[key.rawValue]?.first ?? text.first!
-        }
-        guard let character = character else {
-            return nil
-        }
-        let newCharacter: Character = {
-            if modifiers.contains(.capsLock), character.isLowercaseCharacter {
-                return Character(UnicodeScalar(String(character).unicodeScalars.first!.value - 0x20)!)
-            } else {
-                return character
-            }
-        }()
-        guard let mappedCharacter = keyMap[newCharacter] else {
-            return nil
-        }
-        return mappedCharacter
+    guard let character = map(text: text, key: key, modifiers: modifiers) else {
+      _commitString = nil
+      return .notProcessed
     }
 
-    func input(text: String?,
-               key: KeyCode,
-               modifiers: NSEvent.ModifierFlags,
-               client _: IMKTextInput & IMKUnicodeTextInput) -> InputResult
-    {
-        guard let text = text else {
-            assertionFailure()
-            return .notProcessed
-        }
+    _commitString = "\(character)"
+    return .processed
+  }
 
-        guard !modifiers.contains(.option) else {
-            _commitString = nil
-            return .notProcessed
-        }
+  func candidateSelected(_: NSAttributedString) {}
 
-        guard let character = map(text: text, key: key, modifiers: modifiers) else {
-            _commitString = nil
-            return .notProcessed
-        }
-
-        _commitString = "\(character)"
-        return .processed
-    }
-
-    func candidateSelected(_: NSAttributedString) {}
-
-    func candidateSelectionChanged(_: NSAttributedString) {}
+  func candidateSelectionChanged(_: NSAttributedString) {}
 }
 
 extension RomanComposer: CustomStringConvertible {
-    var description: String {
-        "RomanComposer(.\(String(describing: _composerType)))"
-    }
+  var description: String {
+    "RomanComposer(.\(String(describing: _composerType)))"
+  }
 }
 
 // MARK: - RomanComposerType 열거형 확장
 
 extension RomanComposer.ComposerType {
-    /// 자판 배열 데이터.
-    var keyboardData: String {
-        switch self {
-        case .system:
-            return ""
-        case .qwerty:
-            return ["`1234567890-=\\",
-                    "qwertyuiop[]",
-                    "asdfghjkl;'",
-                    "zxcvbnm,./",
-                    "~!@#$%^&*()_+|",
-                    "QWERTYUIOP{}",
-                    "ASDFGHJKL:\"",
-                    "ZXCVBNM<>?"].reduce("", +)
-        case .dvorak:
-            return ["`1234567890[]\\",
-                    "',.pyfgcrl/=",
-                    "aoeuidhtns-",
-                    ";qjkxbmwvz",
-                    "~!@#$%^&*(){}|",
-                    "\"<>PYFGCRL?+",
-                    "AOEUIDHTNS_",
-                    ":QJKXBMWVZ"].reduce("", +)
-        case .colemak:
-            return ["`1234567890-=\\",
-                    "qwfpgjluy;[]",
-                    "arstdhneio'",
-                    "zxcvbkm,./",
-                    "~!@#$%^&*()_+|",
-                    "QWFPGJLUY:{}",
-                    "ARSTDHNEIO\"",
-                    "ZXCVBKM<>?"].reduce("", +)
-        }
+  /// 자판 배열 데이터.
+  var keyboardData: String {
+    switch self {
+    case .system:
+      return ""
+    case .qwerty:
+      return [
+        "`1234567890-=\\",
+        "qwertyuiop[]",
+        "asdfghjkl;'",
+        "zxcvbnm,./",
+        "~!@#$%^&*()_+|",
+        "QWERTYUIOP{}",
+        "ASDFGHJKL:\"",
+        "ZXCVBNM<>?",
+      ].reduce("", +)
+    case .dvorak:
+      return [
+        "`1234567890[]\\",
+        "',.pyfgcrl/=",
+        "aoeuidhtns-",
+        ";qjkxbmwvz",
+        "~!@#$%^&*(){}|",
+        "\"<>PYFGCRL?+",
+        "AOEUIDHTNS_",
+        ":QJKXBMWVZ",
+      ].reduce("", +)
+    case .colemak:
+      return [
+        "`1234567890-=\\",
+        "qwfpgjluy;[]",
+        "arstdhneio'",
+        "zxcvbkm,./",
+        "~!@#$%^&*()_+|",
+        "QWFPGJLUY:{}",
+        "ARSTDHNEIO\"",
+        "ZXCVBKM<>?",
+      ].reduce("", +)
     }
+  }
 }

--- a/OSXCore/SearchComposer.swift
+++ b/OSXCore/SearchComposer.swift
@@ -11,14 +11,14 @@ import Cocoa
 import Fuse
 import Hangul
 
-let DEBUG_SEARCH_COMPOSER = false
+let debugSearchComposer = false
 
 // MARK: - HGHanjaList 클래스 확장
 
 extension HGHanjaList: Sequence {
-    public func makeIterator() -> NSFastEnumerationIterator {
-        return NSFastEnumerationIterator(self)
-    }
+  public func makeIterator() -> NSFastEnumerationIterator {
+    return NSFastEnumerationIterator(self)
+  }
 }
 
 // MARK: - SearchComposer 클래스
@@ -27,325 +27,339 @@ extension HGHanjaList: Sequence {
 ///
 /// 한자 및 이모지 합성기의 동작을 구현한다.
 final class SearchComposer: Composer {
-    /// 문자를 검색하여 입력하는 합성기가 의존하는 합성기의 종류를 정의한 열거형.
-    enum SourceType {
-        case unknown
-        case hangul
-        case roman
+  /// 문자를 검색하여 입력하는 합성기가 의존하는 합성기의 종류를 정의한 열거형.
+  enum SourceType {
+    case unknown
+    case hangul
+    case roman
+  }
+
+  // MARK: 공통 프로퍼티
+
+  init() {}
+
+  // 검색할 소스
+  var sourceType: SearchComposer.SourceType? {
+    guard let delegate = delegate else {
+      return nil
+    }
+    if delegate is HangulComposer {
+      return .hangul
+    }
+    if delegate is RomanComposer {
+      return .roman
+    }
+    assertionFailure()
+    return nil
+  }
+
+  public private(set) var candidates: [NSAttributedString]?
+  private var _bufferedString = ""
+  public private(set) var composedString = ""
+  public private(set) var commitString = ""
+
+  // 검색을 위한 백그라운드 스레드
+  private var _searchWorkItem = DispatchWorkItem {}
+  private var _searchQueue = DispatchQueue.global(qos: .userInitiated)
+  private let _searchLock = NSLock()
+
+  var showsCandidateWindow = true
+
+  // MARK: Composer 프로토콜 구현
+
+  public var delegate: Composer!
+
+  // 한자 합성의 경우 현재 진행 중인 조합 + 한글 입력기가 지금까지 완료한 조합.
+  var originalString: String {
+    _bufferedString + delegate.composedString
+  }
+
+  var hasCandidates: Bool {
+    !(candidates?.isEmpty ?? true)
+  }
+
+  func dequeueCommitString() -> String {
+    let result = commitString
+    if !result.isEmpty {
+      _bufferedString = ""
+      commitString = ""
+    }
+    return result
+  }
+
+  func cancelComposition() {
+    delegate.cancelComposition()
+    delegate.dequeueCommitString()
+    commitString.append(composedString)
+    _bufferedString = ""
+    composedString = ""
+  }
+
+  func clearCompositionContext() {
+    delegate?.clearCompositionContext()
+  }
+
+  func candidateSelected(_ candidateString: NSAttributedString) {
+    dlog(debugSearchComposer, "DEBUG 1, DelegatedComposer.candidateSelected(_:) function called")
+    let components = candidateString.string.components(separatedBy: ":")
+    guard components.count >= 2 else {
+      return
+    }
+    let candidate = components.first!
+    dlog(
+      debugSearchComposer, "DEBUG 2, DelegatedComposer.candidateSelected(_:) value == %@",
+      candidate)
+    _bufferedString = ""
+    composedString = ""
+    commitString = candidate
+    delegate.cancelComposition()
+    delegate.dequeueCommitString()
+
+    updateCandidates()
+  }
+
+  func candidateSelectionChanged(_: NSAttributedString) {
+    // nothing to do
+  }
+
+  func updateCandidates() {
+    switch sourceType {
+    case .hangul:
+      updateHanjaCandidates()
+    case .roman:
+      updateEmojiCandidates()
+    case .unknown:
+      // TODO: both
+      break
+    case nil:
+      assertionFailure()
+    }
+  }
+
+  func input(
+    text: String?,
+    key keyCode: KeyCode,
+    modifiers flags: NSEvent.ModifierFlags,
+    client sender: IMKTextInput & IMKUnicodeTextInput
+  ) -> InputResult {
+    // 위아래 화살표에 대한 처리 선행
+    switch keyCode {
+    case .upArrow, .downArrow:
+      return InputResult(processed: false, action: .candidatesEvent(keyCode))
+    default:
+      break
     }
 
-    // MARK: 공통 프로퍼티
+    var result = delegate.input(text: text, key: keyCode, modifiers: flags, client: sender)
 
-    init() {}
-
-    // 검색할 소스
-    var sourceType: SearchComposer.SourceType? {
-        guard let delegate = delegate else {
-            return nil
-        }
-        if delegate is HangulComposer {
-            return .hangul
-        }
-        if delegate is RomanComposer {
-            return .roman
-        }
-        assertionFailure()
-        return nil
-    }
-
-    public private(set) var candidates: [NSAttributedString]?
-    private var _bufferedString = ""
-    public private(set) var composedString = ""
-    public private(set) var commitString = ""
-
-    // 검색을 위한 백그라운드 스레드
-    private var _searchWorkItem = DispatchWorkItem {}
-    private var _searchQueue = DispatchQueue.global(qos: .userInitiated)
-    private let _searchLock = NSLock()
-
-    var showsCandidateWindow = true
-
-    // MARK: Composer 프로토콜 구현
-
-    public var delegate: Composer!
-
-    // 한자 합성의 경우 현재 진행 중인 조합 + 한글 입력기가 지금까지 완료한 조합.
-    var originalString: String {
-        _bufferedString + delegate.composedString
-    }
-
-    var hasCandidates: Bool {
-        !(candidates?.isEmpty ?? true)
-    }
-
-    func dequeueCommitString() -> String {
-        let result = commitString
-        if !result.isEmpty {
-            _bufferedString = ""
-            commitString = ""
-        }
-        return result
-    }
-
-    func cancelComposition() {
-        delegate.cancelComposition()
-        delegate.dequeueCommitString()
-        commitString.append(composedString)
-        _bufferedString = ""
-        composedString = ""
-    }
-
-    func clearCompositionContext() {
-        delegate?.clearCompositionContext()
-    }
-
-    func candidateSelected(_ candidateString: NSAttributedString) {
-        dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 1, DelegatedComposer.candidateSelected(_:) function called")
-        let components = candidateString.string.components(separatedBy: ":")
-        guard components.count >= 2 else {
-            return
-        }
-        let candidate = components.first!
-        dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 2, DelegatedComposer.candidateSelected(_:) value == %@", candidate)
-        _bufferedString = ""
-        composedString = ""
-        commitString = candidate
-        delegate.cancelComposition()
-        delegate.dequeueCommitString()
-
-        updateCandidates()
-    }
-
-    func candidateSelectionChanged(_: NSAttributedString) {
-        // nothing to do
-    }
-
-    func updateCandidates() {
-        switch sourceType {
-        case .hangul:
-            updateHanjaCandidates()
-        case .roman:
-            updateEmojiCandidates()
-        case .unknown:
-            // TODO: both
-            break
-        case nil:
-            assertionFailure()
-        }
-    }
-
-    func input(text: String?,
-               key keyCode: KeyCode,
-               modifiers flags: NSEvent.ModifierFlags,
-               client sender: IMKTextInput & IMKUnicodeTextInput) -> InputResult
-    {
-        // 위아래 화살표에 대한 처리 선행
-        switch keyCode {
-        case .upArrow, .downArrow:
-            return InputResult(processed: false, action: .candidatesEvent(keyCode))
-        default:
-            break
-        }
-
-        var result = delegate.input(text: text, key: keyCode, modifiers: flags, client: sender)
-
-        switch keyCode {
-        case .delete:
-            if result == .notProcessed {
-                if !originalString.isEmpty {
-                    // 조합 중인 글자가 없을 때 backspace가 들어오면 조합이 완료된 글자 중 마지막 글자를 지운다.
-                    dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 1, DelegateComposer.input(text:key:modifiers:client:) before (%@)", _bufferedString)
-                    _bufferedString.removeLast()
-                    dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 2, DelegateComposer.input(text:key:modifiers:client:) after (%@)", _bufferedString)
-                    composedString = originalString
-                    result = .processed
-                } else {
-                    showsCandidateWindow = false
-                }
-            }
-        case .space:
-            if sourceType == .hangul {
-                // 강제로 조합 중인 문자 추출
-                delegate.cancelComposition()
-                _bufferedString.append(delegate.dequeueCommitString())
-            }
-            // 단어 뜻 검색을 위해 공백 문자도 후보 검색에 포함한다.
-            if !_bufferedString.isEmpty {
-                _bufferedString.append(" ")
-                result = .processed
-            } else {
-                result = InputResult(processed: false, action: .commit)
-            }
-        case .escape:
-            exitComposer()
-            return InputResult(processed: false, action: .commit)
-        case .return:
-            return InputResult(processed: false, action: .candidatesEvent(keyCode))
-        default:
-            if sourceType == .roman {
-                if result == .notProcessed, let text = text, keyCode.isKeyMappable {
-                    _bufferedString.append(text)
-                    result = .processed
-                }
-            }
-        }
-
-        updateCandidates()
-
-        if !result.processed, result.action == .commit {
-            cancelComposition()
-            return result
-        }
-
-        if commitString.isEmpty {
-            return result == .processed ? .processed : .notProcessed
+    switch keyCode {
+    case .delete:
+      if result == .notProcessed {
+        if !originalString.isEmpty {
+          // 조합 중인 글자가 없을 때 backspace가 들어오면 조합이 완료된 글자 중 마지막 글자를 지운다.
+          dlog(
+            debugSearchComposer,
+            "DEBUG 1, DelegateComposer.input(text:key:modifiers:client:) before (%@)",
+            _bufferedString)
+          _bufferedString.removeLast()
+          dlog(
+            debugSearchComposer,
+            "DEBUG 2, DelegateComposer.input(text:key:modifiers:client:) after (%@)",
+            _bufferedString)
+          composedString = originalString
+          result = .processed
         } else {
-            return InputResult(processed: false, action: .commit)
+          showsCandidateWindow = false
         }
+      }
+    case .space:
+      if sourceType == .hangul {
+        // 강제로 조합 중인 문자 추출
+        delegate.cancelComposition()
+        _bufferedString.append(delegate.dequeueCommitString())
+      }
+      // 단어 뜻 검색을 위해 공백 문자도 후보 검색에 포함한다.
+      if !_bufferedString.isEmpty {
+        _bufferedString.append(" ")
+        result = .processed
+      } else {
+        result = InputResult(processed: false, action: .commit)
+      }
+    case .escape:
+      exitComposer()
+      return InputResult(processed: false, action: .commit)
+    case .return:
+      return InputResult(processed: false, action: .candidatesEvent(keyCode))
+    default:
+      if sourceType == .roman {
+        if result == .notProcessed, let text = text, keyCode.isKeyMappable {
+          _bufferedString.append(text)
+          result = .processed
+        }
+      }
     }
+
+    updateCandidates()
+
+    if !result.processed, result.action == .commit {
+      cancelComposition()
+      return result
+    }
+
+    if commitString.isEmpty {
+      return result == .processed ? .processed : .notProcessed
+    } else {
+      return InputResult(processed: false, action: .commit)
+    }
+  }
 }
 
 // MARK: - SearchComposer 공통 메소드
 
 extension SearchComposer {
-    func update(client sender: IMKTextInput) {
-        dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 1, DelegatedComposer.update(client:) function called")
-        let markedRange = sender.markedRange()
-        let selectedRange = sender.selectedRange()
-        let isInvalidMarkedRage = markedRange.length == 0 || markedRange.location == NSNotFound
-        dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 2, DelegatedComposer.update(client:) DEBUG POINT 1")
-        if isInvalidMarkedRage, selectedRange.location != NSNotFound, selectedRange.length > 0 {
-            let selectedString = sender.attributedSubstring(from: selectedRange).string
-            sender.setMarkedText(selectedString, selectionRange: selectedRange, replacementRange: selectedRange)
-            dlog(DEBUG_SEARCH_COMPOSER,
-                 "DEBUG 3, DelegatedComposer.update(client:) marking: %@ / selected: %@",
-                 NSStringFromRange(sender.markedRange()),
-                 NSStringFromRange(sender.selectedRange()))
-            _bufferedString = selectedString
-            dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 4, DelegatedComposer.update(client:) %@", _bufferedString)
-            if sourceType == .hangul {
-                showsCandidateWindow = false
-            }
-        }
-        dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 5, DelegatedComposer.update(client:) before update candidates")
-        updateCandidates()
-        dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 5, DelegatedComposer.update(client:) after update candidates")
-    }
-
-    func exitComposer() {
-        // 1. 모드 false
+  func update(client sender: IMKTextInput) {
+    dlog(debugSearchComposer, "DEBUG 1, DelegatedComposer.update(client:) function called")
+    let markedRange = sender.markedRange()
+    let selectedRange = sender.selectedRange()
+    let isInvalidMarkedRage = markedRange.length == 0 || markedRange.location == NSNotFound
+    dlog(debugSearchComposer, "DEBUG 2, DelegatedComposer.update(client:) DEBUG POINT 1")
+    if isInvalidMarkedRage, selectedRange.location != NSNotFound, selectedRange.length > 0 {
+      let selectedString = sender.attributedSubstring(from: selectedRange).string
+      sender.setMarkedText(
+        selectedString, selectionRange: selectedRange, replacementRange: selectedRange)
+      dlog(
+        debugSearchComposer,
+        "DEBUG 3, DelegatedComposer.update(client:) marking: %@ / selected: %@",
+        NSStringFromRange(sender.markedRange()),
+        NSStringFromRange(sender.selectedRange()))
+      _bufferedString = selectedString
+      dlog(debugSearchComposer, "DEBUG 4, DelegatedComposer.update(client:) %@", _bufferedString)
+      if sourceType == .hangul {
         showsCandidateWindow = false
-        // 2. 후보 취소
-        cancelSearch()
-        _searchLock.lock()
-        candidates = nil
-        _searchLock.unlock()
-
-        InputMethodServer.shared.candidates.hide()
-
-        // 3. 조합 중인 문자를 모두 가져옴
-        delegate.cancelComposition()
-        _bufferedString.append(delegate.dequeueCommitString())
-        // 4. 그대로 커밋
-        composedString = originalString
-        cancelComposition()
+      }
     }
+    dlog(
+      debugSearchComposer, "DEBUG 5, DelegatedComposer.update(client:) before update candidates")
+    updateCandidates()
+    dlog(
+      debugSearchComposer, "DEBUG 5, DelegatedComposer.update(client:) after update candidates")
+  }
 
-    func searchWorkItem(keyword: String, in source: SearchSource) -> DispatchWorkItem {
-        var workItem: DispatchWorkItem!
-        workItem = DispatchWorkItem {
-            let newCandidates = source.search(keyword, workItem: workItem)
-            guard !workItem.isCancelled else { return }
+  func exitComposer() {
+    // 1. 모드 false
+    showsCandidateWindow = false
+    // 2. 후보 취소
+    cancelSearch()
+    _searchLock.lock()
+    candidates = nil
+    _searchLock.unlock()
 
-            self._searchLock.lock()
-            self.candidates = newCandidates
-            if workItem.isCancelled {
-                self._searchLock.unlock()
-                return
-            }
-            DispatchQueue.main.async {
-                defer { self._searchLock.unlock() }
-                guard self.delegate != nil else {
-                    return
-                }
-                guard !workItem.isCancelled else {
-                    return
-                }
-                InputMethodServer.shared.showOrHideCandidates(composer: self)
-            }
+    InputMethodServer.shared.candidates.hide()
+
+    // 3. 조합 중인 문자를 모두 가져옴
+    delegate.cancelComposition()
+    _bufferedString.append(delegate.dequeueCommitString())
+    // 4. 그대로 커밋
+    composedString = originalString
+    cancelComposition()
+  }
+
+  func searchWorkItem(keyword: String, in source: SearchSource) -> DispatchWorkItem {
+    var workItem: DispatchWorkItem!
+    workItem = DispatchWorkItem {
+      let newCandidates = source.search(keyword, workItem: workItem)
+      guard !workItem.isCancelled else { return }
+
+      self._searchLock.lock()
+      self.candidates = newCandidates
+      if workItem.isCancelled {
+        self._searchLock.unlock()
+        return
+      }
+      DispatchQueue.main.async {
+        defer { self._searchLock.unlock() }
+        guard self.delegate != nil else {
+          return
         }
-        return workItem
-    }
-
-    public func cancelSearch() {
-        if !_searchWorkItem.isCancelled {
-            _searchWorkItem.cancel()
+        guard !workItem.isCancelled else {
+          return
         }
+        InputMethodServer.shared.showOrHideCandidates(composer: self)
+      }
+    }
+    return workItem
+  }
+
+  public func cancelSearch() {
+    if !_searchWorkItem.isCancelled {
+      _searchWorkItem.cancel()
+    }
+  }
+
+  /// 한자 입력을 위한 후보를 만든다.
+  func updateHanjaCandidates() {
+    assert(delegate != nil)
+    assert(sourceType == .hangul)
+
+    dlog(debugSearchComposer, "SearchComposer.updateHanjaCandidates()")
+    // step 1: 한글 입력기에서 조합 완료된 글자를 가져옴
+    let hangulString = delegate.dequeueCommitString()
+    dlog(debugSearchComposer, "SearchComposer.updateHanjaCandidates() step1")
+    _bufferedString.append(hangulString)
+    // step 2: 일단 화면에 한글이 표시되도록 조정
+    dlog(debugSearchComposer, "SearchComposer.updateHanjaCandidates() step2")
+    composedString = originalString
+    // step 3: 키가 없거나 검색 결과가 키 prefix와 일치하지 않으면 후보를 보여주지 않는다.
+    dlog(debugSearchComposer, "SearchComposer.updateHanjaCandidates() step3")
+
+    let keyword = originalString.trimmingCharacters(in: .whitespaces)
+    cancelSearch()
+    candidates = [NSAttributedString(string: "검색 중...")]  // default candidates
+
+    guard !keyword.isEmpty else {
+      dlog(debugSearchComposer, "SearchComposer.updateHanjaCandidates() has no keywords")
+      _searchLock.lock()
+      candidates = nil
+      _searchLock.unlock()
+      return
     }
 
-    /// 한자 입력을 위한 후보를 만든다.
-    func updateHanjaCandidates() {
-        assert(delegate != nil)
-        assert(sourceType == .hangul)
+    dlog(debugSearchComposer, "SearchComposer.updateHanjaCandidates() has candidates")
 
-        dlog(DEBUG_SEARCH_COMPOSER, "SearchComposer.updateHanjaCandidates()")
-        // step 1: 한글 입력기에서 조합 완료된 글자를 가져옴
-        let hangulString = delegate.dequeueCommitString()
-        dlog(DEBUG_SEARCH_COMPOSER, "SearchComposer.updateHanjaCandidates() step1")
-        _bufferedString.append(hangulString)
-        // step 2: 일단 화면에 한글이 표시되도록 조정
-        dlog(DEBUG_SEARCH_COMPOSER, "SearchComposer.updateHanjaCandidates() step2")
-        composedString = originalString
-        // step 3: 키가 없거나 검색 결과가 키 prefix와 일치하지 않으면 후보를 보여주지 않는다.
-        dlog(DEBUG_SEARCH_COMPOSER, "SearchComposer.updateHanjaCandidates() step3")
+    let pool =
+      keyword.count == 1
+      ? SearchSourceConst.koreanSingle : SearchSourceConst.korean
 
-        let keyword = originalString.trimmingCharacters(in: .whitespaces)
-        cancelSearch()
-        candidates = [NSAttributedString(string: "검색 중...")] // default candidates
+    _searchWorkItem = searchWorkItem(keyword: keyword, in: pool)
+    _searchQueue.async(execute: _searchWorkItem)
+  }
 
-        guard !keyword.isEmpty else {
-            dlog(DEBUG_SEARCH_COMPOSER, "SearchComposer.updateHanjaCandidates() has no keywords")
-            _searchLock.lock()
-            candidates = nil
-            _searchLock.unlock()
-            return
-        }
+  func updateEmojiCandidates() {
+    assert(sourceType == .roman)
 
-        dlog(DEBUG_SEARCH_COMPOSER, "SearchComposer.updateHanjaCandidates() has candidates")
+    // Step 1: 의존 합성기로부터 문자열 가져오기
+    let dequeued = delegate.dequeueCommitString()
+    // Step 2: 문자열 보여주기
+    _bufferedString.append(dequeued)
+    _bufferedString.append(delegate.composedString)
+    let originalString = _bufferedString
+    composedString = originalString
+    let keyword = originalString
 
-        let pool = keyword.count == 1
-            ? SearchSourceConst.koreanSingle : SearchSourceConst.korean
+    dlog(debugSearchComposer, "Candidates before search, %@", candidates ?? "nil")
+    cancelSearch()
+    candidates = [NSAttributedString(string: "Searching...")]  // default candidates
+    let pool = SearchSourceConst.emoji
 
-        _searchWorkItem = searchWorkItem(keyword: keyword, in: pool)
-        _searchQueue.async(execute: _searchWorkItem)
+    _searchWorkItem = searchWorkItem(keyword: keyword, in: pool)
+
+    if keyword.isEmpty {
+      _searchLock.lock()
+      candidates = nil
+      _searchLock.unlock()
+    } else {
+      _searchQueue.async(execute: _searchWorkItem)
     }
-
-    func updateEmojiCandidates() {
-        assert(sourceType == .roman)
-
-        // Step 1: 의존 합성기로부터 문자열 가져오기
-        let dequeued = delegate.dequeueCommitString()
-        // Step 2: 문자열 보여주기
-        _bufferedString.append(dequeued)
-        _bufferedString.append(delegate.composedString)
-        let originalString = _bufferedString
-        composedString = originalString
-        let keyword = originalString
-
-        dlog(DEBUG_SEARCH_COMPOSER, "Candidates before search, %@", candidates ?? "nil")
-        cancelSearch()
-        candidates = [NSAttributedString(string: "Searching...")] // default candidates
-        let pool = SearchSourceConst.emoji
-
-        _searchWorkItem = searchWorkItem(keyword: keyword, in: pool)
-
-        if keyword.isEmpty {
-            _searchLock.lock()
-            candidates = nil
-            _searchLock.unlock()
-        } else {
-            _searchQueue.async(execute: _searchWorkItem)
-        }
-        dlog(DEBUG_SEARCH_COMPOSER, "Candidates after search, %@", candidates ?? "nil")
-    }
+    dlog(debugSearchComposer, "Candidates after search, %@", candidates ?? "nil")
+  }
 }

--- a/OSXCore/SearchPool.swift
+++ b/OSXCore/SearchPool.swift
@@ -10,180 +10,197 @@ import Fuse
 import Hangul
 
 struct Candidate: Hashable {
-    var value: String
-    var description: String
+  var value: String
+  var description: String
 }
 
 /// 후보 검색 풀을 추상화한 프로토콜.
 protocol SearchSource {
-    typealias ScoredCandidate = (candidate: Candidate, score: Double)
-    func collect(_ keyword: String, workItem: DispatchWorkItem!) -> [ScoredCandidate]
-    func search(_ keyword: String, workItem: DispatchWorkItem!) -> [NSAttributedString]
+  typealias ScoredCandidate = (candidate: Candidate, score: Double)
+  func collect(_ keyword: String, workItem: DispatchWorkItem!) -> [ScoredCandidate]
+  func search(_ keyword: String, workItem: DispatchWorkItem!) -> [NSAttributedString]
 }
 
 extension SearchSource {
-    func search(_ keyword: String, workItem: DispatchWorkItem!) -> [NSAttributedString] {
-        collect(keyword, workItem: workItem).sorted(by: { $0.score < $1.score }).map {
-            #if DEBUG
-                let s = "\($0.candidate.value): \($0.candidate.description) (\($0.score))"
-            #else
-                let s = "\($0.candidate.value): \($0.candidate.description)"
-            #endif
-            return NSAttributedString(string: s)
-        }
+  func search(_ keyword: String, workItem: DispatchWorkItem!) -> [NSAttributedString] {
+    collect(keyword, workItem: workItem).sorted(by: { $0.score < $1.score }).map {
+      #if DEBUG
+        let s = "\($0.candidate.value): \($0.candidate.description) (\($0.score))"
+      #else
+        let s = "\($0.candidate.value): \($0.candidate.description)"
+      #endif
+      return NSAttributedString(string: s)
     }
+  }
 }
 
 enum SearchSourceConst {
-    static let hanjaCharacter = HanjaTableSearchSource(table: HanjaTableConst.character, method: .exact)
-    static let msSymbol = HanjaTableSearchSource(table: HanjaTableConst.msSymbol, method: .exact)
+  static let hanjaCharacter = HanjaTableSearchSource(
+    table: HanjaTableConst.character, method: .exact)
+  static let msSymbol = HanjaTableSearchSource(table: HanjaTableConst.msSymbol, method: .exact)
 
-    static let hanjaWord = HanjaTableSearchSource(table: HanjaTableConst.word, method: .prefix)
-    static let hanjaReversed = FuseSearchSource(path: hangulBundle.path(forResource: "hanjar", ofType: "txt", inDirectory: "hanja")!, threshold: 0.15)
-    static let emoji = FuseSearchSource(path: hangulBundle.path(forResource: "emoji", ofType: "txt", inDirectory: "hanja")!, threshold: 0.15)
-    static let emojiKorean = FuseSearchSource(path: hangulBundle.path(forResource: "emoji_ko", ofType: "txt", inDirectory: "hanja")!, threshold: 0.15)
+  static let hanjaWord = HanjaTableSearchSource(table: HanjaTableConst.word, method: .prefix)
+  static let hanjaReversed = FuseSearchSource(
+    path: hangulBundle.path(forResource: "hanjar", ofType: "txt", inDirectory: "hanja")!,
+    threshold: 0.15)
+  static let emoji = FuseSearchSource(
+    path: hangulBundle.path(forResource: "emoji", ofType: "txt", inDirectory: "hanja")!,
+    threshold: 0.15)
+  static let emojiKorean = FuseSearchSource(
+    path: hangulBundle.path(forResource: "emoji_ko", ofType: "txt", inDirectory: "hanja")!,
+    threshold: 0.15)
 
-    static let korean = SearchPool(sources: [SearchSourceConst.hanjaWord, SearchSourceConst.hanjaReversed, SearchSourceConst.emojiKorean])
-    static let koreanSingle = SearchPool(sources: [SearchSourceConst.msSymbol, SearchSourceConst.hanjaCharacter] + SearchSourceConst.korean.sources)
+  static let korean = SearchPool(sources: [
+    SearchSourceConst.hanjaWord, SearchSourceConst.hanjaReversed, SearchSourceConst.emojiKorean,
+  ])
+  static let koreanSingle = SearchPool(
+    sources: [SearchSourceConst.msSymbol, SearchSourceConst.hanjaCharacter]
+      + SearchSourceConst.korean.sources)
 }
 
 struct SearchPool: SearchSource {
-    let sources: [SearchSource]
+  let sources: [SearchSource]
 
-    init(sources: [SearchSource]) {
-        self.sources = sources
-    }
-
-    func collect(_ keyword: String, workItem: DispatchWorkItem!) -> [ScoredCandidate] {
-        var candidates: [Candidate: (Double, Int)] = [:]
-        var results: [ScoredCandidate] = []
-        for source in sources {
-            guard !workItem.isCancelled else {
-                break
-            }
-            for item in source.collect(keyword, workItem: workItem) {
-                if let (score, index) = candidates[item.candidate] {
-                    if item.score < score {
-                        candidates[item.candidate] = (item.score, index)
-                        results[index] = item
-                    }
-                } else {
-                    candidates[item.candidate] = (item.score, results.count)
-                    results.append(item)
-                }
-            }
+  func collect(_ keyword: String, workItem: DispatchWorkItem!) -> [ScoredCandidate] {
+    var candidates: [Candidate: (Double, Int)] = [:]
+    var results: [ScoredCandidate] = []
+    for source in sources {
+      guard !workItem.isCancelled else {
+        break
+      }
+      for item in source.collect(keyword, workItem: workItem) {
+        if let (score, index) = candidates[item.candidate] {
+          if item.score < score {
+            candidates[item.candidate] = (item.score, index)
+            results[index] = item
+          }
+        } else {
+          candidates[item.candidate] = (item.score, results.count)
+          results.append(item)
         }
-        return results
+      }
     }
+    return results
+  }
 }
 
 /// `HGHanjaTable`을 검색하는 풀을 나타내는 클래스.
 final class HanjaTableSearchSource: SearchSource {
-    enum Method {
-        case exact
-        case prefix
-    }
+  enum Method {
+    case exact
+    case prefix
+  }
 
-    private let table: HGHanjaTable
-    private let method: HanjaTableSearchSource.Method
+  private let table: HGHanjaTable
+  private let method: HanjaTableSearchSource.Method
 
-    init(table: HGHanjaTable, method: HanjaTableSearchSource.Method) {
-        self.table = table
-        self.method = method
-    }
+  init(table: HGHanjaTable, method: HanjaTableSearchSource.Method) {
+    self.table = table
+    self.method = method
+  }
 
-    /// 키워드를 기준으로 입력할 후보를 검색한다.
-    ///
-    /// - Parameter keyword: 검색 키워드.
-    ///
-    /// - Returns: 후보 문자열과 검색 점수로 이루어진 튜플.
-    func collect(_ keyword: String, workItem: DispatchWorkItem!) -> [ScoredCandidate] {
-        guard let list: HGHanjaList = {
-            switch method {
-            case .exact:
-                return table.hanjasByExact(matching: keyword)
-            case .prefix:
-                // hanjasByPrefix(matching:) 동작 안함
-                return table.hanjas(byPrefixSearching: keyword)
-            }
-        }() else {
-            return []
+  /// 키워드를 기준으로 입력할 후보를 검색한다.
+  ///
+  /// - Parameter keyword: 검색 키워드.
+  ///
+  /// - Returns: 후보 문자열과 검색 점수로 이루어진 튜플.
+  func collect(_ keyword: String, workItem: DispatchWorkItem!) -> [ScoredCandidate] {
+    guard
+      let list: HGHanjaList = {
+        switch method {
+        case .exact:
+          return table.hanjasByExact(matching: keyword)
+        case .prefix:
+          // hanjasByPrefix(matching:) 동작 안함
+          return table.hanjas(byPrefixSearching: keyword)
         }
-
-        var results: [ScoredCandidate] = []
-        for hanja in list {
-            guard !workItem.isCancelled else {
-                break
-            }
-            let hanja = hanja as! HGHanja
-            let score: Double
-            if method == .exact || keyword == hanja.comment {
-                score = 0.0
-            } else {
-                score = 0.025 * Double(hanja.comment.count)
-            }
-            let candidate: Candidate = {
-                if hanja.comment.isEmpty {
-                    return Candidate(value: hanja.value, description: "")
-                } else {
-                    return Candidate(value: hanja.value, description: hanja.comment)
-                }
-            }()
-            results.append((candidate: candidate, score: score))
-        }
-        return results
+      }()
+    else {
+      return []
     }
+
+    var results: [ScoredCandidate] = []
+    for hanja in list {
+      guard !workItem.isCancelled else {
+        break
+      }
+      let hanja = hanja as! HGHanja
+      let score: Double
+      if method == .exact || keyword == hanja.comment {
+        score = 0.0
+      } else {
+        score = 0.025 * Double(hanja.comment.count)
+      }
+      let candidate: Candidate = {
+        if hanja.comment.isEmpty {
+          return Candidate(value: hanja.value, description: "")
+        } else {
+          return Candidate(value: hanja.value, description: hanja.comment)
+        }
+      }()
+      results.append((candidate: candidate, score: score))
+    }
+    return results
+  }
 }
 
 final class FuseSearchSource: SearchSource {
-    struct Word {
-        let completion: String
-        let description: String
+  struct Word {
+    let completion: String
+    let description: String
+  }
+
+  private let fuse: Fuse
+  private let source: [Word]
+  private let strings: [String]
+
+  init(source: [Word], threshold: Double) {
+    fuse = Fuse(threshold: threshold)
+    self.source = source
+    strings = source.map { $0.description }
+  }
+
+  convenience init(path: String, threshold: Double) {
+    let rawData = try! String(contentsOfFile: path, encoding: .utf8)
+    let rows: [String] = rawData.components(separatedBy: .newlines)
+    let source: [Word] = rows.compactMap {
+      guard let first = $0.first else {
+        return nil
+      }
+      guard first != "#" else {
+        return nil
+      }
+      let items = $0.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
+      return Word(completion: String(items[1]), description: String(items[0]))
     }
+    self.init(source: source, threshold: threshold)
+  }
 
-    private let fuse: Fuse
-    private let source: [Word]
-    private let strings: [String]
+  func collect(_ keyword: String, workItem: DispatchWorkItem!) -> [ScoredCandidate] {
+    dlog(
+      debugSearchComposer,
+      "DEBUG 3, DelegatedComposer.updateEmojiCandidates() before hanjasByPrefixSearching")
+    dlog(
+      debugSearchComposer, "DEBUG 4, DelegatedComposer.updateEmojiCandidates() [keyword: %@]",
+      keyword)
+    dlog(
+      debugSearchComposer, "DEBUG 14, DelegatedComposer.updateEmojiCandidates() %@",
+      source.debugDescription)
+    let searchResult = fuse.search(keyword, in: strings)
+    dlog(
+      debugSearchComposer,
+      "DEBUG 5, DelegatedComposer.updateEmojiCandidates() after hanjasByPrefixSearching")
 
-    init(source: [Word], threshold: Double) {
-        fuse = Fuse(threshold: threshold)
-        self.source = source
-        strings = source.map { $0.description }
+    guard !workItem.isCancelled else {
+      return []
     }
-
-    convenience init(path: String, threshold: Double) {
-        let rawData = try! String(contentsOfFile: path, encoding: .utf8)
-        let rows: [String] = rawData.components(separatedBy: .newlines)
-        let source: [Word] = rows.compactMap {
-            guard let first = $0.first else {
-                return nil
-            }
-            guard first != "#" else {
-                return nil
-            }
-            let items = $0.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
-            return Word(completion: String(items[1]), description: String(items[0]))
-        }
-        self.init(source: source, threshold: threshold)
+    return searchResult.map {
+      result in
+      let word = source[result.index]
+      let candidate = Candidate(value: word.completion, description: word.description)
+      return (candidate: candidate, score: result.score + 0.0085 * Double(word.description.count))
     }
-
-    func collect(_ keyword: String, workItem: DispatchWorkItem!) -> [ScoredCandidate] {
-        dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 3, DelegatedComposer.updateEmojiCandidates() before hanjasByPrefixSearching")
-        dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 4, DelegatedComposer.updateEmojiCandidates() [keyword: %@]", keyword)
-        dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 14, DelegatedComposer.updateEmojiCandidates() %@", source.debugDescription)
-        let searchResult = fuse.search(keyword, in: strings)
-        dlog(DEBUG_SEARCH_COMPOSER, "DEBUG 5, DelegatedComposer.updateEmojiCandidates() after hanjasByPrefixSearching")
-
-        guard !workItem.isCancelled else {
-            return []
-        }
-        return searchResult.map {
-            result in
-            let word = source[result.index]
-            let candidate = Candidate(value: word.completion, description: word.description)
-            return (candidate: candidate, score: result.score + 0.0085 * Double(word.description.count))
-        }
-    }
+  }
 }
 
 private let hangulBundle = Bundle(for: HGKeyboard.self)
@@ -192,9 +209,12 @@ private let hangulBundle = Bundle(for: HGKeyboard.self)
 
 /// 한자 테이블을 정리한 열거형.
 enum HanjaTableConst {
-    /// 한자 문자를 모아 놓은 테이블.
-    static let character = HGHanjaTable(contentOfFile: hangulBundle.path(forResource: "hanjac", ofType: "txt", inDirectory: "hanja")!)!
-    /// 한자 단어를 모아 놓은 테이블.
-    static let word = HGHanjaTable(contentOfFile: hangulBundle.path(forResource: "hanjaw", ofType: "txt", inDirectory: "hanja")!)!
-    static let msSymbol = HGHanjaTable(contentOfFile: hangulBundle.path(forResource: "mssymbol", ofType: "txt", inDirectory: "hanja")!)!
+  /// 한자 문자를 모아 놓은 테이블.
+  static let character = HGHanjaTable(
+    contentOfFile: hangulBundle.path(forResource: "hanjac", ofType: "txt", inDirectory: "hanja")!)!
+  /// 한자 단어를 모아 놓은 테이블.
+  static let word = HGHanjaTable(
+    contentOfFile: hangulBundle.path(forResource: "hanjaw", ofType: "txt", inDirectory: "hanja")!)!
+  static let msSymbol = HGHanjaTable(
+    contentOfFile: hangulBundle.path(forResource: "mssymbol", ofType: "txt", inDirectory: "hanja")!)!
 }

--- a/OSXCore/SystemConfigurationWatcher.swift
+++ b/OSXCore/SystemConfigurationWatcher.swift
@@ -12,34 +12,42 @@ import SwiftCoreServices
 typealias FSEventStream = SFSEventStream
 
 public class SystemConfigurationWatcher {
-    var configuration: Configuration
+  var configuration: Configuration
 
-    static let globalPreferencesPath: String = {
-        let libraryURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
-        let fileURL = URL(fileURLWithPath: "Preferences/.GlobalPreferences.plist", relativeTo: libraryURL)
-        return fileURL.path
-    }()
+  static let globalPreferencesPath: String = {
+    let libraryURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
+    let fileURL = URL(
+      fileURLWithPath: "Preferences/.GlobalPreferences.plist", relativeTo: libraryURL)
+    return fileURL.path
+  }()
 
-    init(configuration: inout Configuration) {
-        self.configuration = configuration
+  init(configuration: inout Configuration) {
+    self.configuration = configuration
 
-        let stream = FSEventStream.create(paths: [SystemConfigurationWatcher.globalPreferencesPath], eventId: FSEventStream.EventIdSinceNow, latancy: 5.0, flags: FSEventStream.CreateFlag.fileEvents) {
-            [weak self] _, _ in
-            NSLog("Reloading system configuration by watcher")
-            self?.reloadConfiguration()
-        }!
-        stream.schedule(runLoop: .current, mode: .default)
-        stream.start()
+    let stream = FSEventStream.create(
+      paths: [SystemConfigurationWatcher.globalPreferencesPath],
+      eventId: FSEventStream.EventIdSinceNow, latancy: 5.0,
+      flags: FSEventStream.CreateFlag.fileEvents
+    ) {
+      [weak self] _, _ in
+      NSLog("Reloading system configuration by watcher")
+      self?.reloadConfiguration()
+    }!
+    stream.schedule(runLoop: .current, mode: .default)
+    stream.start()
+  }
+
+  public func reloadConfiguration() {
+    guard
+      let globalPreferences = NSDictionary(
+        contentsOf: URL(fileURLWithPath: SystemConfigurationWatcher.globalPreferencesPath))
+    else {
+      return
     }
 
-    public func reloadConfiguration() {
-        guard let globalPreferences = NSDictionary(contentsOf: URL(fileURLWithPath: SystemConfigurationWatcher.globalPreferencesPath)) else {
-            return
-        }
-
-        let state: Int = (globalPreferences["TISRomanSwitchState"] as? NSNumber)?.intValue ?? 1
-        configuration.enableCapslockToToggleInputMode = state > 0
-    }
+    let state: Int = (globalPreferences["TISRomanSwitchState"] as? NSNumber)?.intValue ?? 1
+    configuration.enableCapslockToToggleInputMode = state > 0
+  }
 }
 
 public let watcher = SystemConfigurationWatcher(configuration: &Configuration.shared)

--- a/OSXTestApp/AppDelegate.swift
+++ b/OSXTestApp/AppDelegate.swift
@@ -10,11 +10,11 @@ import Cocoa
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
-    func applicationDidFinishLaunching(_: Notification) {
-        // Insert code here to initialize your application
-    }
+  func applicationDidFinishLaunching(_: Notification) {
+    // Insert code here to initialize your application
+  }
 
-    func applicationWillTerminate(_: Notification) {
-        // Insert code here to tear down your application
-    }
+  func applicationWillTerminate(_: Notification) {
+    // Insert code here to tear down your application
+  }
 }

--- a/OSXTestApp/TestViewController.swift
+++ b/OSXTestApp/TestViewController.swift
@@ -7,84 +7,93 @@
 //
 
 import Cocoa
+
 @testable import GureumCore
 
 @objc(PreferenceViewController)
 class PreferenceViewController: NSViewController {
-    private let _isAtLeast10_15 = ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 10, minorVersion: 15, patchVersion: 0))
+  private let isAtLeast1015 = ProcessInfo().isOperatingSystemAtLeast(
+    OperatingSystemVersion(majorVersion: 10, minorVersion: 15, patchVersion: 0))
 
-    override func loadView() {
-        let path = Bundle.main.path(forResource: "Preferences", ofType: "prefPane")
-        let bundle = NSPrefPaneBundle(path: path)!
-        assert(bundle.bundle != nil)
-        assert(bundle.bundle.principalClass != nil)
-        if _isAtLeast10_15 {
-            let pane = NSPreferencePane(bundle: bundle.bundle)
-            pane.loadMainView()
-            view = pane.mainView
-        } else {
-            let loaded = bundle.instantiatePrefPaneObject()
-            assert(loaded)
-            let pane = bundle.prefPaneObject()!
-            view = pane.mainView
-        }
+  override func loadView() {
+    let path = Bundle.main.path(forResource: "Preferences", ofType: "prefPane")
+    let bundle = NSPrefPaneBundle(path: path)!
+    assert(bundle.bundle != nil)
+    assert(bundle.bundle.principalClass != nil)
+    if isAtLeast1015 {
+      let pane = NSPreferencePane(bundle: bundle.bundle)
+      pane.loadMainView()
+      view = pane.mainView
+    } else {
+      let loaded = bundle.instantiatePrefPaneObject()
+      assert(loaded)
+      let pane = bundle.prefPaneObject()!
+      view = pane.mainView
     }
+  }
 }
 
 class TestViewController: NSViewController {
-    @IBOutlet var textField: NSTextField!
-    @IBOutlet var inputClient: MockInputClient!
-    var inputController: InputController!
+  @IBOutlet var textField: NSTextField!
+  @IBOutlet var inputClient: MockInputClient!
+  var inputController: InputController!
 
-    override func viewDidLoad() {
-        assert(inputClient != nil)
-        inputController = MockInputController(server: InputMethodServer.shared.server, delegate: self, client: inputClient!)
-        NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged], handler: {
-            event in
-            // print(event)
-            assert(self.inputController != nil)
-            assert(self.inputClient != nil)
-            guard event.type == .keyDown else {
-                _ = self.inputController.handle(event, client: self.inputClient!)
-                return nil
-            }
-            guard let keyCode = KeyCode(rawValue: Int(event.keyCode)) else { return nil }
-            let selected = self.inputClient.selectedRange()
-            let marked = self.inputClient.markedRange()
-            if keyCode == .delete, selected.length > 0, selected != marked {
-                self.inputController.cancelComposition()
-                self.inputClient.insertText("", replacementRange: selected)
-                self.inputClient.setMarkedText("", selectionRange: NSRange(location: 0, length: 0), replacementRange: NSRange(location: selected.location, length: 0))
-                return nil
-            }
-            let processed = self.inputController.handle(event, client: self.inputClient!)
-            if processed {
-                // self.inputController.updateComposition()
-                return nil
-            }
-            let specialFlags = event.modifierFlags.intersection([.command, .control])
-            if !specialFlags.isEmpty {
-                return event
-            }
-            self.inputController.cancelComposition()
-            self.inputController.commitComposition(self.inputClient)
-            if keyCode == .delete {
-                NSLog("\(self.inputClient.selectedRange())")
-                // let marked = self.inputClient.markedRange()
-                if self.inputClient.hasMarkedText() {
-                    self.inputClient.insertText("", replacementRange: marked)
-                } else if selected.location > 0 {
-                    let deleted = NSRange(location: selected.location - 1, length: 1)
-                    self.inputClient.insertText("", replacementRange: deleted)
-                    let marking = NSRange(location: deleted.location, length: 0)
-                    self.inputClient.setMarkedText("", selectionRange: NSRange(location: 0, length: 0), replacementRange: marking)
-                }
-            } else if keyCode.isKeyMappable {
-                self.inputClient.insertText(event.characters, replacementRange: self.inputClient.markedRange())
-            } else {
-                return event
-            }
-            return nil
-        })
-    }
+  override func viewDidLoad() {
+    assert(inputClient != nil)
+    inputController = MockInputController(
+      server: InputMethodServer.shared.server, delegate: self, client: inputClient!)
+    NSEvent.addLocalMonitorForEvents(
+      matching: [.keyDown, .flagsChanged],
+      handler: {
+        event in
+        // print(event)
+        assert(self.inputController != nil)
+        assert(self.inputClient != nil)
+        guard event.type == .keyDown else {
+          _ = self.inputController.handle(event, client: self.inputClient!)
+          return nil
+        }
+        guard let keyCode = KeyCode(rawValue: Int(event.keyCode)) else { return nil }
+        let selected = self.inputClient.selectedRange()
+        let marked = self.inputClient.markedRange()
+        if keyCode == .delete, selected.length > 0, selected != marked {
+          self.inputController.cancelComposition()
+          self.inputClient.insertText("", replacementRange: selected)
+          self.inputClient.setMarkedText(
+            "", selectionRange: NSRange(location: 0, length: 0),
+            replacementRange: NSRange(location: selected.location, length: 0))
+          return nil
+        }
+        let processed = self.inputController.handle(event, client: self.inputClient!)
+        if processed {
+          // self.inputController.updateComposition()
+          return nil
+        }
+        let specialFlags = event.modifierFlags.intersection([.command, .control])
+        if !specialFlags.isEmpty {
+          return event
+        }
+        self.inputController.cancelComposition()
+        self.inputController.commitComposition(self.inputClient)
+        if keyCode == .delete {
+          NSLog("\(self.inputClient.selectedRange())")
+          // let marked = self.inputClient.markedRange()
+          if self.inputClient.hasMarkedText() {
+            self.inputClient.insertText("", replacementRange: marked)
+          } else if selected.location > 0 {
+            let deleted = NSRange(location: selected.location - 1, length: 1)
+            self.inputClient.insertText("", replacementRange: deleted)
+            let marking = NSRange(location: deleted.location, length: 0)
+            self.inputClient.setMarkedText(
+              "", selectionRange: NSRange(location: 0, length: 0), replacementRange: marking)
+          }
+        } else if keyCode.isKeyMappable {
+          self.inputClient.insertText(
+            event.characters, replacementRange: self.inputClient.markedRange())
+        } else {
+          return event
+        }
+        return nil
+      })
+  }
 }

--- a/Preferences/GureumPreferencePane.swift
+++ b/Preferences/GureumPreferencePane.swift
@@ -10,9 +10,9 @@ import Cocoa
 import PreferencePanes
 
 final class GureumPreferencePane: NSPreferencePane {
-    @IBOutlet private var viewController: NSViewController!
+  @IBOutlet private var viewController: NSViewController!
 
-    override func mainViewDidLoad() {
-        super.mainViewDidLoad()
-    }
+  override func mainViewDidLoad() {
+    super.mainViewDidLoad()
+  }
 }

--- a/Preferences/GureumShortcutValidator.swift
+++ b/Preferences/GureumShortcutValidator.swift
@@ -10,33 +10,38 @@ import Foundation
 import MASShortcut
 
 #if !USE_PREFPANE
-    import GureumCore
+  import GureumCore
 #endif
 
 final class GureumShortcutValidator: MASShortcutValidator {
-    override init() {
-        super.init()
-        allowAnyShortcutWithOptionModifier = true
-    }
+  override init() {
+    super.init()
+    allowAnyShortcutWithOptionModifier = true
+  }
 
-    override func isShortcutAlreadyTaken(bySystem _: MASShortcut!, explanation _: AutoreleasingUnsafeMutablePointer<NSString?>!) -> Bool {
-        return false
-    }
+  override func isShortcutAlreadyTaken(
+    bySystem _: MASShortcut!, explanation _: AutoreleasingUnsafeMutablePointer<NSString?>!
+  ) -> Bool {
+    return false
+  }
 
-    override func isShortcutValid(_ shortcut: MASShortcut!) -> Bool {
-        if super.isShortcutValid(shortcut) {
-            return true
-        }
-        let modifiers = shortcut.modifierFlags
-        let keyCode = shortcut.keyCode
-        guard (modifiers.rawValue & NSEvent.ModifierFlags.shift.rawValue) > 0 else {
-            return false
-        }
-        guard let key = KeyCode(rawValue: keyCode) else { return false }
-        return !key.isKeyMappable || [.return, .tab, .space].contains(key)
+  override func isShortcutValid(_ shortcut: MASShortcut!) -> Bool {
+    if super.isShortcutValid(shortcut) {
+      return true
     }
+    let modifiers = shortcut.modifierFlags
+    let keyCode = shortcut.keyCode
+    guard (modifiers.rawValue & NSEvent.ModifierFlags.shift.rawValue) > 0 else {
+      return false
+    }
+    guard let key = KeyCode(rawValue: keyCode) else { return false }
+    return !key.isKeyMappable || [.return, .tab, .space].contains(key)
+  }
 
-    override func isShortcut(_: MASShortcut!, alreadyTakenIn _: NSMenu!, explanation _: AutoreleasingUnsafeMutablePointer<NSString?>!) -> Bool {
-        return false
-    }
+  override func isShortcut(
+    _: MASShortcut!, alreadyTakenIn _: NSMenu!,
+    explanation _: AutoreleasingUnsafeMutablePointer<NSString?>!
+  ) -> Bool {
+    return false
+  }
 }

--- a/Preferences/PreferenceViewController.swift
+++ b/Preferences/PreferenceViewController.swift
@@ -9,7 +9,6 @@
 import Cocoa
 import Foundation
 import MASShortcut
-import SwiftIOKit
 
 #if !USE_PREFPANE
   import GureumCore

--- a/Preferences/PreferenceViewController.swift
+++ b/Preferences/PreferenceViewController.swift
@@ -8,349 +8,372 @@
 
 import Cocoa
 import Foundation
+import MASShortcut
 import SwiftIOKit
 
-import MASShortcut
 #if !USE_PREFPANE
-    import GureumCore
+  import GureumCore
 #endif
 
 @objc(PreferenceViewController)
 final class PreferenceViewController: NSViewController {
-    @IBOutlet private var debugButton: NSButton!
-    /// 옵션 키 동작.
-    @IBOutlet private var optionKeyBehaviorButton: NSPopUpButton!
-    /// 기본 키보드 레이아웃.
-    @IBOutlet private var overridingKeyboardNameComboBox: NSComboBoxCell!
+  @IBOutlet private var debugButton: NSButton!
+  /// 옵션 키 동작.
+  @IBOutlet private var optionKeyBehaviorButton: NSPopUpButton!
+  /// 기본 키보드 레이아웃.
+  @IBOutlet private var overridingKeyboardNameComboBox: NSComboBoxCell!
 
-    /// 한글 입력기일 때 역따옴표(`)로 원화 기호(₩) 입력.
-    @IBOutlet private var hangulWonCurrencySymbolForBackQuoteButton: NSButton!
-    /// 완성되지 않은 낱자 자동 교정 (모아치기).
-    @IBOutlet private var hangulAutoReorderButton: NSButton!
-    /// 두벌식 초성 조합 중에도 종성 결합 허용 (MS윈도 호환).
-    @IBOutlet private var hangulNonChoseongCombinationButton: NSButton!
-    /// 모든 글자를 조합중인 글자로 취급 (JDK 호환).
-    @IBOutlet private var hangulDeferredSymbolCommitButton: NSButton!
-    /// 세벌식 정석 강요.
-    @IBOutlet private var hangulForceStrictCombinationRuleButton: NSButton!
-    /// Esc 키로 로마자 자판으로 전환 (vi 모드).
-    @IBOutlet private var romanModeByEscapeKeyButton: NSButton!
-    /// 우측 키로 언어 전환
-    @IBOutlet private var rightToggleKeyButton: NSPopUpButton!
+  /// 한글 입력기일 때 역따옴표(`)로 원화 기호(₩) 입력.
+  @IBOutlet private var hangulWonCurrencySymbolForBackQuoteButton: NSButton!
+  /// 완성되지 않은 낱자 자동 교정 (모아치기).
+  @IBOutlet private var hangulAutoReorderButton: NSButton!
+  /// 두벌식 초성 조합 중에도 종성 결합 허용 (MS윈도 호환).
+  @IBOutlet private var hangulNonChoseongCombinationButton: NSButton!
+  /// 모든 글자를 조합중인 글자로 취급 (JDK 호환).
+  @IBOutlet private var hangulDeferredSymbolCommitButton: NSButton!
+  /// 세벌식 정석 강요.
+  @IBOutlet private var hangulForceStrictCombinationRuleButton: NSButton!
+  /// Esc 키로 로마자 자판으로 전환 (vi 모드).
+  @IBOutlet private var romanModeByEscapeKeyButton: NSButton!
+  /// 우측 키로 언어 전환
+  @IBOutlet private var rightToggleKeyButton: NSPopUpButton!
 
-    /// 입력기 바꾸기 단축키.
-    @IBOutlet private var inputModeExchangeShortcutView: MASShortcutView!
-    /// 한자 및 이모지 검색 단축키.
-    @IBOutlet private var inputModeSearchShortcutView: MASShortcutView!
-    /// 로마자로 바꾸기 단축키.
-    @IBOutlet private var inputModeEnglishShortcutView: MASShortcutView!
-    /// 한글로 바꾸기 단축키.
-    @IBOutlet private var inputModeKoreanShortcutView: MASShortcutView!
+  /// 입력기 바꾸기 단축키.
+  @IBOutlet private var inputModeExchangeShortcutView: MASShortcutView!
+  /// 한자 및 이모지 검색 단축키.
+  @IBOutlet private var inputModeSearchShortcutView: MASShortcutView!
+  /// 로마자로 바꾸기 단축키.
+  @IBOutlet private var inputModeEnglishShortcutView: MASShortcutView!
+  /// 한글로 바꾸기 단축키.
+  @IBOutlet private var inputModeKoreanShortcutView: MASShortcutView!
 
-    /// 업데이트 알림 받기
-    @IBOutlet private var updateNotificationButton: NSButton!
-    /// 실험버전 업데이트 알림 받기
-    @IBOutlet private var updateNotificationExperimentalButton: NSButton!
+  /// 업데이트 알림 받기
+  @IBOutlet private var updateNotificationButton: NSButton!
+  /// 실험버전 업데이트 알림 받기
+  @IBOutlet private var updateNotificationExperimentalButton: NSButton!
 
-    private let configuration = Configuration()
-    private let pane: GureumPreferencePane! = nil
-    private let shortcutValidator = GureumShortcutValidator()
-    private let backgroundQueue = DispatchQueue.global(qos: .background)
+  private let configuration = Configuration()
+  private let pane: GureumPreferencePane! = nil
+  private let shortcutValidator = GureumShortcutValidator()
+  private let backgroundQueue = DispatchQueue.global(qos: .background)
 
-    private lazy var inputSources: [(identifier: String, localizedName: String)] = {
-        let abcIdentifier = "com.apple.keylayout.ABC"
+  private lazy var inputSources: [(identifier: String, localizedName: String)] = {
+    let abcIdentifier = "com.apple.keylayout.ABC"
 
-        guard let rawSources = TISInputSource.sources(withProperties: [kTISPropertyInputSourceType!: kTISTypeKeyboardLayout!, kTISPropertyInputSourceIsASCIICapable!: true], includeAllInstalled: true) else {
-            return []
-        }
+    guard
+      let rawSources = TISInputSource.sources(
+        withProperties: [
+          kTISPropertyInputSourceType!: kTISTypeKeyboardLayout!,
+          kTISPropertyInputSourceIsASCIICapable!: true,
+        ], includeAllInstalled: true)
+    else {
+      return []
+    }
 
-        let unsortedSources = rawSources.map { (identifier: $0.identifier, localizedName: $0.localizedName, enabled: $0.enabled) }
-        let sortedSources = unsortedSources.sorted {
-            if $0.identifier == abcIdentifier {
-                return true
-            } else if $1.identifier == abcIdentifier {
-                return false
-            }
-            if $0.enabled != $1.enabled {
-                return $0.enabled
-            }
-            return $0.localizedName < $1.localizedName
-        }
-        let sources = sortedSources.map { (identifier: $0.identifier, localizedName: $0.localizedName) }
-        return sources
+    let unsortedSources = rawSources.map {
+      (identifier: $0.identifier, localizedName: $0.localizedName, enabled: $0.enabled)
+    }
+    let sortedSources = unsortedSources.sorted {
+      if $0.identifier == abcIdentifier {
+        return true
+      } else if $1.identifier == abcIdentifier {
+        return false
+      }
+      if $0.enabled != $1.enabled {
+        return $0.enabled
+      }
+      return $0.localizedName < $1.localizedName
+    }
+    let sources = sortedSources.map { (identifier: $0.identifier, localizedName: $0.localizedName) }
+    return sources
+  }()
+
+  override func viewDidLoad() {
+    hangulWonCurrencySymbolForBackQuoteButton.state = isOn(
+      configuration.hangulWonCurrencySymbolForBackQuote)
+    romanModeByEscapeKeyButton.state = isOn(configuration.romanModeByEscapeKey)
+    hangulAutoReorderButton.state = isOn(configuration.hangulAutoReorder)
+    hangulNonChoseongCombinationButton.state = isOn(configuration.hangulNonChoseongCombination)
+    hangulDeferredSymbolCommitButton.state = isOn(configuration.hangulDeferredSymbolCommit)
+    hangulForceStrictCombinationRuleButton.state = isOn(
+      configuration.hangulForceStrictCombinationRule)
+    switch configuration.rightToggleKey {
+    case kHIDUsage_KeyboardRightGUI:
+      rightToggleKeyButton.selectItem(at: 1)
+    case kHIDUsage_KeyboardRightAlt:
+      rightToggleKeyButton.selectItem(at: 2)
+    case kHIDUsage_KeyboardRightControl:
+      rightToggleKeyButton.selectItem(at: 3)
+    default:
+      rightToggleKeyButton.selectItem(at: 0)
+    }
+    if (0..<optionKeyBehaviorButton.numberOfItems).contains(configuration.optionKeyBehavior) {
+      optionKeyBehaviorButton.selectItem(at: configuration.optionKeyBehavior)
+    }
+
+    overridingKeyboardNameComboBox.reloadData()
+    if let selectedIndex = inputSources.firstIndex(where: {
+      $0.identifier == configuration.overridingKeyboardName
+    }) {
+      overridingKeyboardNameComboBox.selectItem(at: selectedIndex)
+    }
+
+    inputModeExchangeShortcutView.shortcutValidator = shortcutValidator
+    inputModeSearchShortcutView.shortcutValidator = shortcutValidator
+    inputModeEnglishShortcutView.shortcutValidator = shortcutValidator
+    inputModeKoreanShortcutView.shortcutValidator = shortcutValidator
+
+    loadShortcutValues()
+    setupShortcutViewValueChangeEvents()
+
+    updateNotificationButton.state = isOn(configuration.updateNotification)
+    if Bundle.main.isExperimental {
+      updateNotificationExperimentalButton.state = .on
+      updateNotificationExperimentalButton.isEnabled = false
+    } else {
+      updateNotificationExperimentalButton.state = isOn(
+        configuration.updateNotificationExperimental)
+    }
+
+    #if DEBUG
+      debugButton.isHidden = false
+    #endif
+  }
+
+  private func runAppleScript(_ script: String) {
+    var error: NSDictionary?
+    if let scriptObject = NSAppleScript(source: script) {
+      let output: NSAppleEventDescriptor = scriptObject.executeAndReturnError(
+        &error
+      )
+      print("pref event descriptor: \(output.stringValue ?? "nil")")
+    }
+  }
+
+  // MARK: IBAction
+
+  @IBAction private func debug(sender _: NSControl) {
+    print("killing myself")
+    let x = [0]
+    _ = x[1]
+  }
+
+  @IBAction private func openKeyboardShortcutsPreference(sender _: NSControl) {
+    if #available(OSX 13, *) {
+      runAppleScript(
+        """
+            do shell script "open -b com.apple.systempreferences /System/Library/PreferencePanes/Keyboard.prefPane"
+        """)
+    } else {
+      runAppleScript(
+        """
+            tell application "System Preferences"
+                activate
+                reveal anchor "ShortcutsTab" of pane id "com.apple.preference.keyboard"
+            end tell
+        """)
+    }
+  }
+
+  @IBAction private func openKeyboardInputSourcesPreference(sender _: NSControl) {
+    if #available(OSX 13, *) {
+      runAppleScript(
+        """
+            do shell script "open -b com.apple.systempreferences /System/Library/PreferencePanes/Keyboard.prefPane"
+        """)
+    } else {
+      runAppleScript(
+        """
+            tell application "System Preferences"
+                activate
+                reveal anchor "InputSources" of pane id "com.apple.preference.keyboard"
+            end tell
+        """)
+    }
+  }
+
+  @IBAction private func openInputMonitoringPreference(sender _: NSControl) {
+    if #available(OSX 13, *) {
+      runAppleScript(
+        """
+            do shell script "open x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+        """)
+    } else {
+      runAppleScript(
+        """
+            tell application "System Preferences"
+                activate
+                reveal anchor "Privacy" of pane id "com.apple.preference.security"
+            end tell
+        """)
+    }
+  }
+
+  @IBAction private func updateCheck(sender _: NSControl) {
+    updateCheck()
+  }
+
+  @IBAction private func optionKeyBehaviorValueChanged(_ sender: NSPopUpButton) {
+    configuration.optionKeyBehavior = sender.indexOfSelectedItem
+  }
+
+  @IBAction private func overridingKeyboardNameComboBoxValueChanged(_ sender: NSComboBox) {
+    guard (0..<inputSources.count).contains(sender.indexOfSelectedItem) else {
+      return
+    }
+    configuration.overridingKeyboardName = inputSources[sender.indexOfSelectedItem].identifier
+  }
+
+  @IBAction private func romanModeByEscapeKeyValueChanged(_ sender: NSButton) {
+    configuration.romanModeByEscapeKey = sender.state == .on
+  }
+
+  @IBAction private func hangulWonCurrencySymbolForBackQuoteValueChanged(_ sender: NSButton) {
+    configuration.hangulWonCurrencySymbolForBackQuote = sender.state == .on
+  }
+
+  @IBAction private func hangulAutoReorderValueChanged(_ sender: NSButton) {
+    configuration.hangulAutoReorder = sender.state == .on
+  }
+
+  @IBAction private func hangulNonChoseongCombinationValueChanged(_ sender: NSButton) {
+    configuration.hangulNonChoseongCombination = sender.state == .on
+  }
+
+  @IBAction private func hangulDeferredSymbolCommitValueChanged(_ sender: NSButton) {
+    configuration.hangulDeferredSymbolCommit = sender.state == .on
+  }
+
+  @IBAction private func hangulForceStrictCombinationRuleValueChanged(_ sender: NSButton) {
+    configuration.hangulForceStrictCombinationRule = sender.state == .on
+  }
+
+  @IBAction private func rightToggleKeyValueChanged(_ sender: NSPopUpButton) {
+    configuration.rightToggleKey = {
+      switch sender.indexOfSelectedItem {
+      case 1:
+        return kHIDUsage_KeyboardRightGUI
+      case 2:
+        return kHIDUsage_KeyboardRightAlt
+      case 3:
+        return kHIDUsage_KeyboardRightControl
+      default:
+        return 0
+      }
     }()
+  }
 
-    override func viewDidLoad() {
-        hangulWonCurrencySymbolForBackQuoteButton.state = isOn(configuration.hangulWonCurrencySymbolForBackQuote)
-        romanModeByEscapeKeyButton.state = isOn(configuration.romanModeByEscapeKey)
-        hangulAutoReorderButton.state = isOn(configuration.hangulAutoReorder)
-        hangulNonChoseongCombinationButton.state = isOn(configuration.hangulNonChoseongCombination)
-        hangulDeferredSymbolCommitButton.state = isOn(configuration.hangulDeferredSymbolCommit)
-        hangulForceStrictCombinationRuleButton.state = isOn(configuration.hangulForceStrictCombinationRule)
-        switch configuration.rightToggleKey {
-        case kHIDUsage_KeyboardRightGUI:
-            rightToggleKeyButton.selectItem(at: 1)
-        case kHIDUsage_KeyboardRightAlt:
-            rightToggleKeyButton.selectItem(at: 2)
-        case kHIDUsage_KeyboardRightControl:
-            rightToggleKeyButton.selectItem(at: 3)
-        default:
-            rightToggleKeyButton.selectItem(at: 0)
-        }
-        if (0 ..< optionKeyBehaviorButton.numberOfItems).contains(configuration.optionKeyBehavior) {
-            optionKeyBehaviorButton.selectItem(at: configuration.optionKeyBehavior)
-        }
-
-        overridingKeyboardNameComboBox.reloadData()
-        if let selectedIndex = inputSources.firstIndex(where: { $0.identifier == configuration.overridingKeyboardName }) {
-            overridingKeyboardNameComboBox.selectItem(at: selectedIndex)
-        }
-
-        inputModeExchangeShortcutView.shortcutValidator = shortcutValidator
-        inputModeSearchShortcutView.shortcutValidator = shortcutValidator
-        inputModeEnglishShortcutView.shortcutValidator = shortcutValidator
-        inputModeKoreanShortcutView.shortcutValidator = shortcutValidator
-
-        loadShortcutValues()
-        setupShortcutViewValueChangeEvents()
-
-        updateNotificationButton.state = isOn(configuration.updateNotification)
-        if Bundle.main.isExperimental {
-            updateNotificationExperimentalButton.state = .on
-            updateNotificationExperimentalButton.isEnabled = false
-        } else {
-            updateNotificationExperimentalButton.state = isOn(configuration.updateNotificationExperimental)
-        }
-
-        #if DEBUG
-            debugButton.isHidden = false
-        #endif
+  @IBAction private func updateNotificationValueChanged(_ sender: NSButton) {
+    configuration.updateNotification = sender.state == .on
+    if !Bundle.main.isExperimental {
+      updateNotificationExperimentalButton.isEnabled = sender.state == .on
     }
-
-    private func runAppleScript(_ script: String) {
-        var error: NSDictionary?
-        if let scriptObject = NSAppleScript(source: script) {
-            let output: NSAppleEventDescriptor = scriptObject.executeAndReturnError(
-                &error
-            )
-            print("pref event descriptor: \(output.stringValue ?? "nil")")
-        }
+    backgroundQueue.async {
+      self.updateCheck()
     }
+  }
 
-    // MARK: IBAction
-
-    @IBAction private func debug(sender _: NSControl) {
-        print("killing myself")
-        let x = [0]
-        _ = x[1]
+  @IBAction private func updateNotificationExperimentalValueChanged(_ sender: NSButton) {
+    configuration.updateNotificationExperimental = sender.state == .on
+    backgroundQueue.async {
+      self.updateCheck()
     }
-
-    @IBAction private func openKeyboardShortcutsPreference(sender _: NSControl) {
-        if #available(OSX 13, *) {
-            runAppleScript("""
-                do shell script "open -b com.apple.systempreferences /System/Library/PreferencePanes/Keyboard.prefPane"
-            """)
-        } else {
-            runAppleScript("""
-                tell application "System Preferences"
-                    activate
-                    reveal anchor "ShortcutsTab" of pane id "com.apple.preference.keyboard"
-                end tell
-            """)
-        }
-    }
-
-    @IBAction private func openKeyboardInputSourcesPreference(sender _: NSControl) {
-        if #available(OSX 13, *) {
-            runAppleScript("""
-                do shell script "open -b com.apple.systempreferences /System/Library/PreferencePanes/Keyboard.prefPane"
-            """)
-        } else {
-            runAppleScript("""
-                tell application "System Preferences"
-                    activate
-                    reveal anchor "InputSources" of pane id "com.apple.preference.keyboard"
-                end tell
-            """)
-        }
-    }
-
-    @IBAction private func openInputMonitoringPreference(sender _: NSControl) {
-        if #available(OSX 13, *) {
-            runAppleScript("""
-                do shell script "open x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
-            """)
-        } else {
-            runAppleScript("""
-                tell application "System Preferences"
-                    activate
-                    reveal anchor "Privacy" of pane id "com.apple.preference.security"
-                end tell
-            """)
-        }
-    }
-
-    @IBAction private func updateCheck(sender _: NSControl) {
-        updateCheck()
-    }
-
-    @IBAction private func optionKeyBehaviorValueChanged(_ sender: NSPopUpButton) {
-        configuration.optionKeyBehavior = sender.indexOfSelectedItem
-    }
-
-    @IBAction private func overridingKeyboardNameComboBoxValueChanged(_ sender: NSComboBox) {
-        guard (0 ..< inputSources.count).contains(sender.indexOfSelectedItem) else {
-            return
-        }
-        configuration.overridingKeyboardName = inputSources[sender.indexOfSelectedItem].identifier
-    }
-
-    @IBAction private func romanModeByEscapeKeyValueChanged(_ sender: NSButton) {
-        configuration.romanModeByEscapeKey = sender.state == .on
-    }
-
-    @IBAction private func hangulWonCurrencySymbolForBackQuoteValueChanged(_ sender: NSButton) {
-        configuration.hangulWonCurrencySymbolForBackQuote = sender.state == .on
-    }
-
-    @IBAction private func hangulAutoReorderValueChanged(_ sender: NSButton) {
-        configuration.hangulAutoReorder = sender.state == .on
-    }
-
-    @IBAction private func hangulNonChoseongCombinationValueChanged(_ sender: NSButton) {
-        configuration.hangulNonChoseongCombination = sender.state == .on
-    }
-
-    @IBAction private func hangulDeferredSymbolCommitValueChanged(_ sender: NSButton) {
-        configuration.hangulDeferredSymbolCommit = sender.state == .on
-    }
-
-    @IBAction private func hangulForceStrictCombinationRuleValueChanged(_ sender: NSButton) {
-        configuration.hangulForceStrictCombinationRule = sender.state == .on
-    }
-
-    @IBAction private func rightToggleKeyValueChanged(_ sender: NSPopUpButton) {
-        configuration.rightToggleKey = {
-            switch sender.indexOfSelectedItem {
-            case 1:
-                return kHIDUsage_KeyboardRightGUI
-            case 2:
-                return kHIDUsage_KeyboardRightAlt
-            case 3:
-                return kHIDUsage_KeyboardRightControl
-            default:
-                return 0
-            }
-        }()
-    }
-
-    @IBAction private func updateNotificationValueChanged(_ sender: NSButton) {
-        configuration.updateNotification = sender.state == .on
-        if !Bundle.main.isExperimental {
-            updateNotificationExperimentalButton.isEnabled = sender.state == .on
-        }
-        backgroundQueue.async {
-            self.updateCheck()
-        }
-    }
-
-    @IBAction private func updateNotificationExperimentalValueChanged(_ sender: NSButton) {
-        configuration.updateNotificationExperimental = sender.state == .on
-        backgroundQueue.async {
-            self.updateCheck()
-        }
-    }
+  }
 }
 
 // MARK: - 비공개 메소드
 
-private extension PreferenceViewController {
-    func isOn(_ value: Bool) -> NSButton.StateValue {
-        return value ? .on : .off
+extension PreferenceViewController {
+  fileprivate func isOn(_ value: Bool) -> NSButton.StateValue {
+    return value ? .on : .off
+  }
+
+  fileprivate func loadShortcutValues() {
+    if let key = configuration.inputModeExchangeKey {
+      inputModeExchangeShortcutView.shortcutValue = MASShortcut(
+        keyCode: key.0.rawValue, modifierFlags: key.1)
+    } else {
+      inputModeExchangeShortcutView.shortcutValue = nil
     }
 
-    func loadShortcutValues() {
-        if let key = configuration.inputModeExchangeKey {
-            inputModeExchangeShortcutView.shortcutValue = MASShortcut(keyCode: key.0.rawValue, modifierFlags: key.1)
-        } else {
-            inputModeExchangeShortcutView.shortcutValue = nil
-        }
-
-        if let key = configuration.inputModeSearchKey {
-            inputModeSearchShortcutView.shortcutValue = MASShortcut(keyCode: key.0.rawValue, modifierFlags: key.1)
-        } else {
-            inputModeSearchShortcutView.shortcutValue = nil
-        }
-
-        if let key = configuration.inputModeEnglishKey {
-            inputModeEnglishShortcutView.shortcutValue = MASShortcut(keyCode: key.0.rawValue, modifierFlags: key.1)
-        } else {
-            inputModeEnglishShortcutView.shortcutValue = nil
-        }
-
-        if let key = configuration.inputModeKoreanKey {
-            inputModeKoreanShortcutView.shortcutValue = MASShortcut(keyCode: key.0.rawValue, modifierFlags: key.1)
-        } else {
-            inputModeKoreanShortcutView.shortcutValue = nil
-        }
+    if let key = configuration.inputModeSearchKey {
+      inputModeSearchShortcutView.shortcutValue = MASShortcut(
+        keyCode: key.0.rawValue, modifierFlags: key.1)
+    } else {
+      inputModeSearchShortcutView.shortcutValue = nil
     }
 
-    func setupShortcutViewValueChangeEvents() {
-        func masShortcutToShortcut(_ mas: MASShortcut?) -> Configuration.Shortcut? {
-            guard let mas = mas, let keyCode = KeyCode(rawValue: mas.keyCode) else { return nil }
-            return (keyCode, mas.modifierFlags)
-        }
-        inputModeExchangeShortcutView.shortcutValueChange = { sender in
-            self.configuration.inputModeExchangeKey = masShortcutToShortcut(sender.shortcutValue)
-        }
-
-        inputModeSearchShortcutView.shortcutValueChange = { sender in
-            self.configuration.inputModeSearchKey = masShortcutToShortcut(sender.shortcutValue)
-        }
-
-        inputModeEnglishShortcutView.shortcutValueChange = { sender in
-            self.configuration.inputModeEnglishKey = masShortcutToShortcut(sender.shortcutValue)
-        }
-
-        inputModeKoreanShortcutView.shortcutValueChange = { sender in
-            self.configuration.inputModeKoreanKey = masShortcutToShortcut(sender.shortcutValue)
-        }
+    if let key = configuration.inputModeEnglishKey {
+      inputModeEnglishShortcutView.shortcutValue = MASShortcut(
+        keyCode: key.0.rawValue, modifierFlags: key.1)
+    } else {
+      inputModeEnglishShortcutView.shortcutValue = nil
     }
 
-    func updateCheck() {
-        #if !USE_PREFPANE
-            UpdateManager.shared.requestAutoUpdateVersionInfo { info in
-                guard let info = info else {
-                    return
-                }
-                UpdateManager.notifyUpdate(info: info)
-            }
-        #endif
+    if let key = configuration.inputModeKoreanKey {
+      inputModeKoreanShortcutView.shortcutValue = MASShortcut(
+        keyCode: key.0.rawValue, modifierFlags: key.1)
+    } else {
+      inputModeKoreanShortcutView.shortcutValue = nil
     }
+  }
+
+  fileprivate func setupShortcutViewValueChangeEvents() {
+    func masShortcutToShortcut(_ mas: MASShortcut?) -> Configuration.Shortcut? {
+      guard let mas = mas, let keyCode = KeyCode(rawValue: mas.keyCode) else { return nil }
+      return (keyCode, mas.modifierFlags)
+    }
+    inputModeExchangeShortcutView.shortcutValueChange = { sender in
+      self.configuration.inputModeExchangeKey = masShortcutToShortcut(sender.shortcutValue)
+    }
+
+    inputModeSearchShortcutView.shortcutValueChange = { sender in
+      self.configuration.inputModeSearchKey = masShortcutToShortcut(sender.shortcutValue)
+    }
+
+    inputModeEnglishShortcutView.shortcutValueChange = { sender in
+      self.configuration.inputModeEnglishKey = masShortcutToShortcut(sender.shortcutValue)
+    }
+
+    inputModeKoreanShortcutView.shortcutValueChange = { sender in
+      self.configuration.inputModeKoreanKey = masShortcutToShortcut(sender.shortcutValue)
+    }
+  }
+
+  fileprivate func updateCheck() {
+    #if !USE_PREFPANE
+      UpdateManager.shared.requestAutoUpdateVersionInfo { info in
+        guard let info = info else {
+          return
+        }
+        UpdateManager.notifyUpdate(info: info)
+      }
+    #endif
+  }
 }
 
 // MARK: - NSComboBoxDataSource 구현
 
 extension PreferenceViewController: NSComboBoxDataSource {
-    func numberOfItems(in _: NSComboBox) -> Int {
-        return inputSources.count
-    }
+  func numberOfItems(in _: NSComboBox) -> Int {
+    return inputSources.count
+  }
 
-    func comboBox(_: NSComboBox, objectValueForItemAt index: Int) -> Any? {
-        return inputSources[index].localizedName
-    }
+  func comboBox(_: NSComboBox, objectValueForItemAt index: Int) -> Any? {
+    return inputSources[index].localizedName
+  }
 
-    func comboBox(_: NSComboBox, indexOfItemWithStringValue string: String) -> Int {
-        return inputSources.firstIndex(where: { $0.localizedName == string }) ?? NSNotFound
-    }
+  func comboBox(_: NSComboBox, indexOfItemWithStringValue string: String) -> Int {
+    return inputSources.firstIndex(where: { $0.localizedName == string }) ?? NSNotFound
+  }
 
-    func comboBox(_: NSComboBox, completedString string: String) -> String? {
-        for source in inputSources {
-            if source.localizedName.starts(with: string) {
-                return source.localizedName
-            }
-        }
-        overridingKeyboardNameComboBox.stringValue = ""
-        return ""
+  func comboBox(_: NSComboBox, completedString string: String) -> String? {
+    for source in inputSources {
+      if source.localizedName.starts(with: string) {
+        return source.localizedName
+      }
     }
+    overridingKeyboardNameComboBox.stringValue = ""
+    return ""
+  }
 }

--- a/Preferences/TISInputSource+.swift
+++ b/Preferences/TISInputSource+.swift
@@ -10,30 +10,32 @@ import Carbon
 import Foundation
 
 // pod으로 설치하면 정상적으로 불러와지지 않는다
-public extension TISInputSource {
-    class func sources(withProperties properties: NSDictionary, includeAllInstalled: Bool) -> [TISInputSource]? {
-        guard let unmanaged = TISCreateInputSourceList(properties, includeAllInstalled) else {
-            return nil
-        }
-        return unmanaged.takeRetainedValue() as? [TISInputSource]
+extension TISInputSource {
+  public class func sources(withProperties properties: NSDictionary, includeAllInstalled: Bool)
+    -> [TISInputSource]?
+  {
+    guard let unmanaged = TISCreateInputSourceList(properties, includeAllInstalled) else {
+      return nil
     }
+    return unmanaged.takeRetainedValue() as? [TISInputSource]
+  }
 
-    func property(forKey key: String) -> Any? {
-        guard let unmanaged = TISGetInputSourceProperty(self, key as CFString) else {
-            return nil
-        }
-        return Unmanaged<AnyObject>.fromOpaque(unmanaged).takeUnretainedValue()
+  public func property(forKey key: String) -> Any? {
+    guard let unmanaged = TISGetInputSourceProperty(self, key as CFString) else {
+      return nil
     }
+    return Unmanaged<AnyObject>.fromOpaque(unmanaged).takeUnretainedValue()
+  }
 
-    var enabled: Bool {
-        return property(forKey: kTISPropertyInputSourceIsEnabled as String) as! Bool
-    }
+  public var enabled: Bool {
+    return property(forKey: kTISPropertyInputSourceIsEnabled as String) as! Bool
+  }
 
-    var identifier: String {
-        return property(forKey: kTISPropertyInputSourceID as String) as! String
-    }
+  public var identifier: String {
+    return property(forKey: kTISPropertyInputSourceID as String) as! String
+  }
 
-    var localizedName: String {
-        return property(forKey: kTISPropertyLocalizedName as String) as! String
-    }
+  public var localizedName: String {
+    return property(forKey: kTISPropertyLocalizedName as String) as! String
+  }
 }


### PR DESCRIPTION
## Summary

Adopt Apple's **swift-format** (the formatter bundled with the Swift/Xcode toolchain) as the project's standard formatter, replacing nicklockwood's SwiftFormat, and reformat the codebase to its default configuration.

The previous CI installed nicklockwood SwiftFormat at `version: '*'` (unpinned) with no config file, so formatting drifted with every release. swift-format ships with the toolchain (Swift 6 / Xcode 16+), needs no install, and is version-aligned to the compiler. No `.swift-format` file is added — the pure toolchain default is used.

## Changes

- **`def3a70` Reformat + default lint compliance** (30 `.swift` files): applied `swift format`'s default configuration to `OSXCore`, `OSX`, `GureumTests`, `Preferences`, `OSXTestApp`, and fixed the lint-only findings the formatter cannot auto-fix:
  - Renamed constants/enum cases to lowerCamelCase (`AlwaysUseLowerCamelCase`) — e.g. `DEBUG_LOGGING → debugLogging`, `UpdateMode.Stable → .stable`, `han3_2011 → han32011` (raw values preserved).
  - Converted HeaderDoc block comments to line comments and removed dead commented-out Objective-C blocks (`NoBlockComments`).
  - Removed a redundant initializer (`UseSynthesizedInitializer`) and moved an overlong end-of-line comment (`EndOfLineComment`).
- **`b8a4fc4` Tooling swap**: the CI job now runs `swift format lint --strict` on `macos-latest` (bundled swift-format); the `Makefile` `format` target uses `swift format` and drops the Homebrew swiftformat install; `HACKING.md` updated.
- **`ba43773` Build fix**: removed an unused `import SwiftIOKit` from `PreferenceViewController.swift` (dead since 2019; Xcode's explicit-module build could not resolve it because the Preferences target declares no `SwiftUp` product dependency).

## Verification (Xcode 26.5 / swift-format 6.3)

- `swift format lint --strict` over all five directories → **0 findings**
- `xcodebuild -scheme OSX build` → **BUILD SUCCEEDED**
- `xcodebuild -scheme OSX build-for-testing` → **TEST BUILD SUCCEEDED**

## Notes for reviewers

- The CI job was renamed `swiftformat` → `swift-format`. **If branch protection requires the old check name, update it.**
- CI lints with the swift-format bundled in `macos-latest`'s Xcode. If the runner's Xcode diverges from developers' Xcode, default rules could differ; pin the Xcode version if exact reproducibility is desired.
- Scope is unchanged from the previous CI (the five macOS directories); the `iOS*` targets are not formatted, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
