### PR TITLE
Fix SearchComposer deadlock from lock held across async dispatch

### DIFF
--- a/OSXCore/SearchComposer.swift
+++ b/OSXCore/SearchComposer.swift
@@ -272,12 +272,10 @@ extension SearchComposer {
 
       self._searchLock.lock()
       self.candidates = newCandidates
-      if workItem.isCancelled {
-        self._searchLock.unlock()
-        return
-      }
+      self._searchLock.unlock()
+
+      guard !workItem.isCancelled else { return }
       DispatchQueue.main.async {
-        defer { self._searchLock.unlock() }
         guard self.delegate != nil else {
           return
         }


### PR DESCRIPTION
## Summary

`SearchComposer.searchWorkItem(keyword:in:)` acquired `_searchLock` on the background search queue and released it **inside** the `DispatchQueue.main.async` block:

```swift
self._searchLock.lock()
self.candidates = newCandidates
...
DispatchQueue.main.async {
    defer { self._searchLock.unlock() }   // released only when the main queue drains
    ...
}
```

When the main thread runs synchronously through a path that also takes `_searchLock` — e.g. `updateEmojiCandidates()`'s empty-keyword branch (reached right after `candidateSelected`), `updateHanjaCandidates()`'s empty-keyword branch, or `exitComposer()` — the main queue cannot drain that `async` block, so the lock stays held and the **main thread deadlocks on `lock()`**. It is a timing race: it depends on whether a background search finished and took the lock before the main thread reaches its own `lock()`.

This is a real bug in the input method (rapid emoji/hanja search followed by selection can hang it), and it surfaced as the **intermittent 6-hour CI hang** in `build-and-test`.

## Root-cause evidence

- The hung CI job always stops right after `testPreferencePane`, i.e. at **`testRomanEmoticon`** — the test exercising the async emoji search + candidate-selection path.
- It is a **race**, not a deterministic UI/window-server problem: the hanja candidate tests (`testHanjaWord`, `testHanjaSyllable`) run the same async search + `showOrHideCandidates` path **earlier** and pass in CI. A deterministic `IMKCandidates.show()` hang would stop an earlier test.
- Reproduced deterministically **locally** by forcing the timing (a temporary `Thread.sleep(0.3)` before `candidateSelected`): `testRomanEmoticon` then hung and XCTest reported *"The test may have hung"*.
- With this fix and the same forced timing, `testRomanEmoticon` passes (0.38s).

## Fix

Release `_searchLock` on the background thread right after updating `candidates`, before dispatching the candidate-window update to the main queue. The lock is never held across the queue boundary, so the main thread can no longer deadlock waiting for a main-queue block to release it.

## Verification (Xcode 26.5)

- Forced-timing repro: **fails (hangs) before**, **passes after**.
- Full suite `xcodebuild -scheme OSX test` → **Executed 44 tests, 0 failures — TEST SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)