### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
           sdk: macosx
           destination: platform=macOS
           action: build test
+          output-formatter: xcpretty --color
       #- uses: sersoft-gmbh/xcodebuild-action@v4
       #  with:
       #    workspace: Gureum.xcworkspace
@@ -39,3 +40,4 @@ jobs:
       #    sdk: iphonesimulator
       #    destination: platform=iOS Simulator,OS=11.3,name=iPhone X
       #    action: build test
+      #    output-formatter: xcpretty --color

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:
@@ -16,23 +16,23 @@ jobs:
   swift-format:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - run: swift format lint --strict --recursive OSXCore OSX GureumTests Preferences OSXTestApp
   build-and-test:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: sersoft-gmbh/xcodebuild-action@v3
+      - uses: sersoft-gmbh/xcodebuild-action@v4
         with:
           project: Gureum.xcodeproj
           scheme: OSX
           sdk: macosx
           destination: platform=macOS
           action: build test
-      #- uses: sersoft-gmbh/xcodebuild-action@v3
+      #- uses: sersoft-gmbh/xcodebuild-action@v4
       #  with:
       #    workspace: Gureum.xcworkspace
       #    scheme: App


### PR DESCRIPTION
`xcodebuild-actions@v3` 실행 시 Node 20 환경을 사용하는 것 같습니다.

- https://github.com/gureum/gureum/actions/runs/28910549874/job/85766835393

> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

xcodebuild-action 4.0에서 Node 24로 전환했습니다.

- https://github.com/sersoft-gmbh/xcodebuild-action/releases/tag/v4.0.0

actions/checkout도 단순 업데이트합니다.