### PR TITLE
Confine SearchComposer candidates to the main thread

### DIFF
--- a/OSXCore/SearchComposer.swift
+++ b/OSXCore/SearchComposer.swift
@@ -61,7 +61,6 @@ final class SearchComposer: Composer {
   // 검색을 위한 백그라운드 스레드
   private var _searchWorkItem = DispatchWorkItem {}
   private var _searchQueue = DispatchQueue.global(qos: .userInitiated)
-  private let _searchLock = NSLock()
 
   var showsCandidateWindow = true
 
@@ -250,9 +249,7 @@ extension SearchComposer {
     showsCandidateWindow = false
     // 2. 후보 취소
     cancelSearch()
-    _searchLock.lock()
     candidates = nil
-    _searchLock.unlock()
 
     InputMethodServer.shared.candidates.hide()
 
@@ -270,11 +267,7 @@ extension SearchComposer {
       let newCandidates = source.search(keyword, workItem: workItem)
       guard !workItem.isCancelled else { return }
 
-      self._searchLock.lock()
-      self.candidates = newCandidates
-      self._searchLock.unlock()
-
-      guard !workItem.isCancelled else { return }
+      // candidates는 메인 스레드에서만 접근하므로 결과 반영도 메인 큐에서 수행한다.
       DispatchQueue.main.async {
         guard self.delegate != nil else {
           return
@@ -282,6 +275,7 @@ extension SearchComposer {
         guard !workItem.isCancelled else {
           return
         }
+        self.candidates = newCandidates
         InputMethodServer.shared.showOrHideCandidates(composer: self)
       }
     }
@@ -316,9 +310,7 @@ extension SearchComposer {
 
     guard !keyword.isEmpty else {
       dlog(debugSearchComposer, "SearchComposer.updateHanjaCandidates() has no keywords")
-      _searchLock.lock()
       candidates = nil
-      _searchLock.unlock()
       return
     }
 
@@ -352,9 +344,7 @@ extension SearchComposer {
     _searchWorkItem = searchWorkItem(keyword: keyword, in: pool)
 
     if keyword.isEmpty {
-      _searchLock.lock()
       candidates = nil
-      _searchLock.unlock()
     } else {
       _searchQueue.async(execute: _searchWorkItem)
     }


### PR DESCRIPTION
## 요약

`SearchComposer.candidates`는 백그라운드 검색 큐에서 `_searchLock`을 잡고 쓰지만, 메인 스레드에서는 락 없이 읽고 씁니다(`검색 중...`/`Searching...` 플레이스홀더, `hasCandidates`, IMK에 넘기는 `InputReceiver.candidates(_:)`). 한쪽만 락을 잡으니 상호배제가 성립하지 않습니다. 백그라운드 검색이 끝나며 `candidates`를 쓰는 순간 사용자가 다음 키를 입력해 메인 스레드에서 그 COW 배열을 읽으면 torn read / `EXC_BAD_ACCESS` 위험이 있습니다.

이는 방금 병합된 #928(데드락)과 **같은 `_searchLock`의 다른 결함**입니다.

## 수정

`candidates` 갱신을 `searchWorkItem`의 메인 큐 블록 안에서만 수행하도록 옮겨 **메인 스레드 전용**으로 만들고, 이제 불필요해진 `_searchLock`을 제거했습니다. 백그라운드는 검색 결과 계산만 담당하고, 배열 대입과 후보창 표시는 모두 메인 큐에서 일어납니다.

## 검증

- `xcodebuild -scheme OSX test` → **44 tests, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
