### PR TITLE
Guard against invalid update URL in notification handler

### DIFF
--- a/OSX/GureumAppDelegate.swift
+++ b/OSX/GureumAppDelegate.swift
@@ -31,8 +31,8 @@ class NotificationCenterDelegate: NSObject, NSUserNotificationCenterDelegate {
     default:
       break
     }
-    if updating {
-      NSWorkspace.shared.open(URL(string: download)!)
+    if updating, let url = URL(string: download) {
+      NSWorkspace.shared.open(url)
     }
     answers.logUpdateNotification(updating: updating)
   }


### PR DESCRIPTION
## 요약

업데이트 알림의 `userInfo["url"]` 값은 원격 버전 JSON(`gureum.io/version.json`)의 `url` 필드에서 채워집니다(`UpdateManager`). 이 값이 파싱 불가한 문자열(예: 공백 포함)이면 `URL(string:)`이 `nil`을 반환하는데, 이를 `!`로 강제 언랩하고 있어 **사용자가 업데이트 알림을 클릭하는 순간 입력기 프로세스가 크래시**합니다.

`GureumMenu.swift`의 동일한 값 처리 경로는 이미 `if let url = URL(string:)`으로 방어하고 있어 두 경로가 불일치 상태였습니다.

## 수정

알림 핸들러에서도 동일하게 URL을 옵셔널 바인딩으로 가드합니다. URL이 유효하지 않으면 여는 동작만 건너뛰고, 나머지 로깅은 그대로 수행합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
