### PR TITLE
Avoid crashing Preferences on input sources lacking TIS properties

### DIFF
--- a/Preferences/TISInputSource+.swift
+++ b/Preferences/TISInputSource+.swift
@@ -28,14 +28,14 @@ extension TISInputSource {
   }
 
   public var enabled: Bool {
-    return property(forKey: kTISPropertyInputSourceIsEnabled as String) as! Bool
+    return property(forKey: kTISPropertyInputSourceIsEnabled as String) as? Bool ?? false
   }
 
   public var identifier: String {
-    return property(forKey: kTISPropertyInputSourceID as String) as! String
+    return property(forKey: kTISPropertyInputSourceID as String) as? String ?? ""
   }
 
   public var localizedName: String {
-    return property(forKey: kTISPropertyLocalizedName as String) as! String
+    return property(forKey: kTISPropertyLocalizedName as String) as? String ?? identifier
   }
 }


### PR DESCRIPTION
## 요약

`TISInputSource`의 `enabled` / `identifier` / `localizedName`은 `property(forKey:)`가 돌려주는 옵셔널 값을 `as!`로 강제 캐스팅합니다. 환경설정 화면은 `includeAllInstalled: true`로 **설치된 모든 ASCII 자판**을 순회하며 이 세 값을 읽는데, `kTISPropertyLocalizedName`은 NULL일 수 있다고 문서화되어 있습니다. 값이 없는 자판이 하나라도 있으면 `as!`가 트랩되어 **환경설정 창 전체가 로드에 실패**합니다.

## 수정

세 접근자를 `as?` + 합리적 폴백으로 바꿔 크래시를 제거합니다.

- `enabled` → `as? Bool ?? false`
- `identifier` → `as? String ?? ""`
- `localizedName` → `as? String ?? identifier`

## 검증

- `xcodebuild -scheme Preferences build` → **BUILD SUCCEEDED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
