### PR TITLE
Guard HangulComposer against keys with no character

### DIFF
--- a/OSXCore/HangulComposer.swift
+++ b/OSXCore/HangulComposer.swift
@@ -232,14 +232,20 @@ final class HangulComposer: NSObject, Composer {
       return InputResult(processed: false, action: .commit)
     }
 
-    var string = string!
+    var string = string ?? ""
     // 한글 입력에서 캡스락 무시
     if flags.contains(.shift) {
       string = keyMapUpper[keyCode.rawValue] ?? string
     } else {
       string = keyMapLower[keyCode.rawValue] ?? string
     }
-    let handled = inputContext.process(string.unicodeScalars.first!.value)
+    guard let scalar = string.unicodeScalars.first else {
+      // mappable 키인데 이벤트에 문자가 없는 비정상 입력. 정상 입력에서는 도달하지 않으므로
+      // 디버그에서는 노출시키고, 릴리스에서는 크래시 대신 조합 없이 통과시킨다.
+      assertionFailure("mappable key \(keyCode) produced no character")
+      return InputResult(processed: false, action: .commit)
+    }
+    let handled = inputContext.process(scalar.value)
     let ucsString = inputContext.commitUCSString
     let recentCommitString = representableString(ucsString: ucsString)
 
@@ -277,7 +283,7 @@ final class HangulComposer: NSObject, Composer {
       if !handled {
         _commitString.append(recentCommitString + "₩")
         return .processed
-      } else if recentCommitString.last! == "`" {
+      } else if recentCommitString.hasSuffix("`") {
         _commitString.append(recentCommitString.dropLast() + "₩")
         return .processed
       }


### PR DESCRIPTION
## 요약

`HangulComposer.input(...)`이 `var string = string!` 이후 `inputContext.process(string.unicodeScalars.first!.value)`로 강제 언랩을 두 번 합니다.

keyMap에 매핑이 없으면서(그리고 상단에서 걸러지지 않는) mappable 키는 `isoSection`(ISO 자판의 § 키) 하나뿐인데, 정상적인 § 입력은 이벤트에 자체 문자를 담고 있어 이 언랩에 도달하지 않고 정상적으로 커밋됩니다. 즉 **빈 문자열로 이 지점에 도달한다는 것은 "문자를 내야 할 키가 문자를 내지 않은" 비정상 상황**입니다. 정상 입력에서는 사실상 도달 불가입니다.

## 수정

- 강제 언랩(force-unwrap)만 제거하되 정상 케이스인 척하지 않습니다: 문자가 없으면 디버그에서는 `assertionFailure`로 즉시 드러내고, 릴리스에서는 크래시 대신 조합 없이 통과시킵니다.
- ₩ 변환 경로의 `recentCommitString.last!`도 빈 커밋 문자열에서 트랩되지 않도록 `hasSuffix`로 바꿨습니다.

## 검증

- `xcodebuild -scheme OSX test` → **44 tests, 0 failures** (테스트는 isoSection을 입력하지 않으므로 `assertionFailure`가 발화하지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
