### PR TITLE
Preserve non-search prefix when committing hanja/emoji candidate

### DIFF
--- a/GureumTests/GureumTests.swift
+++ b/GureumTests/GureumTests.swift
@@ -300,6 +300,27 @@ class GureumTests: XCTestCase {
     }
   }
 
+  func testHanjaSelectionWithPrefix() {
+    for app in apps {
+      if app == terminal {
+        continue  // 터미널은 한자 모드 진입이 불가능
+      }
+      // 검색 대상이 아닌 접두사(문장부호·공백)가 앞에 붙은 채로 한자 모드에 들어간다.
+      app.client.string = "(물 수"
+      app.controller.setValue(
+        GureumInputSource.han3Final.rawValue,
+        forTag: kTextServiceInputModePropertyTag, client: app.client)
+      app.client.setSelectedRange(NSMakeRange(0, 4))
+      XCTAssertEqual("(물 수", app.client.selectedString(), "")
+      app.inputText("\n", key: .return, modifiers: .option)
+      XCTAssertEqual("(물 수", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+      app.controller.candidateSelected(NSAttributedString(string: "水: 물 수, 고를 수"))
+      // 접두사 "("는 그대로 두고 뒤의 "물 수"만 선택한 한자로 교체한다.
+      XCTAssertEqual("(水", app.client.string, "buffer: \(app.client.string) app: \(app)")
+      XCTAssertEqual("", app.client.markedString(), "buffer: \(app.client.string) app: \(app)")
+    }
+  }
+
   func testHanjaEscapeSyllable() {
     for app in apps {
       if app == terminal {

--- a/OSXCore/SearchComposer.swift
+++ b/OSXCore/SearchComposer.swift
@@ -109,9 +109,11 @@ final class SearchComposer: Composer {
     dlog(
       debugSearchComposer, "DEBUG 2, DelegatedComposer.candidateSelected(_:) value == %@",
       candidate)
+    // 검색 대상이 아닌 접두사(공백·문장부호 등)는 그대로 두고 뒤의 한글/로마자만 후보로 교체한다.
+    let (prefix, _) = splitSearchKeyword(originalString)
     _bufferedString = ""
     composedString = ""
-    commitString = candidate
+    commitString = prefix + candidate
     delegate.cancelComposition()
     delegate.dequeueCommitString()
 
@@ -120,6 +122,13 @@ final class SearchComposer: Composer {
 
   func candidateSelectionChanged(_: NSAttributedString) {
     // nothing to do
+  }
+
+  /// 입력값 앞에 붙은 검색 대상이 아닌 접두사(공백·문장부호 등)와 실제 검색 대상(한글/로마자)을 분리한다.
+  /// 접두사는 검색에서 제외하고, 후보를 커밋할 때 그대로 앞에 붙여 뒤의 한글/로마자만 교체한다.
+  private func splitSearchKeyword(_ string: String) -> (prefix: String, body: String) {
+    let bodyStart = string.firstIndex(where: { $0.isLetter }) ?? string.endIndex
+    return (String(string[..<bodyStart]), String(string[bodyStart...]))
   }
 
   func updateCandidates() {
@@ -310,7 +319,8 @@ extension SearchComposer {
     // step 3: 키가 없거나 검색 결과가 키 prefix와 일치하지 않으면 후보를 보여주지 않는다.
     dlog(debugSearchComposer, "SearchComposer.updateHanjaCandidates() step3")
 
-    let keyword = originalString.trimmingCharacters(in: .whitespaces)
+    let (_, body) = splitSearchKeyword(originalString)
+    let keyword = body.trimmingCharacters(in: .whitespaces)
     cancelSearch()
     candidates = [NSAttributedString(string: "검색 중...")]  // default candidates
 
@@ -342,7 +352,8 @@ extension SearchComposer {
     _bufferedString.append(delegate.composedString)
     let originalString = _bufferedString
     composedString = originalString
-    let keyword = originalString
+    let (_, body) = splitSearchKeyword(originalString)
+    let keyword = body
 
     dlog(debugSearchComposer, "Candidates before search, %@", candidates ?? "nil")
     cancelSearch()


### PR DESCRIPTION
## 요약

한자·이모지 연속 입력에서 검색어 앞에 붙은 **검색 대상이 아닌 접두사**(공백·문장부호·기호 등)를 검색에서 제외하고, 후보를 커밋할 때는 그 접두사를 그대로 보존하도록 개선합니다.

기존에는 공백/문장부호로 시작하는 입력(예: 선택 영역을 한자 모드로 넘기거나, 문장부호를 먼저 친 뒤 한글 입력)에서 접두사까지 검색어에 포함되어 후보를 못 찾거나, 후보 선택 시 접두사가 사라지는 문제가 있었습니다.

## 수정

- 헬퍼 `splitSearchKeyword(_:)` 추가: 문자열을 첫 글자(한글/로마자) 위치 기준으로 `(prefix, body)`로 분리합니다. prefix = 앞쪽 비검색 대상, body = 첫 한글/로마자부터 끝까지.
- `updateHanjaCandidates` / `updateEmojiCandidates`: 검색어를 `body`에서 도출(앞 접두사 제외).
- `candidateSelected`: `commitString = prefix + candidate`로 커밋하여 뒤의 한글/로마자만 선택한 한자/이모지로 교체.
- 접두사가 없으면 기존 동작과 100% 동일합니다.

## 검증

- `testHanjaSelectionWithPrefix` 추가: `(물 수` 선택 → 한자 모드 → `水` 선택 → 결과 `(水` 검증 (기존 코드에선 `水`가 나와 실패).
- `xcodebuild -scheme OSX test` → **45 tests, 0 failures**
- `swift format lint --strict` 통과