### PR TITLE
Bound libhangul buffer reads in convertUnicode and representableString

### DIFF
--- a/OSXCore/HangulComposer.swift
+++ b/OSXCore/HangulComposer.swift
@@ -33,13 +33,19 @@ private let table: [HGUCSChar: HGUCSChar] = [
 func convertUnicode(_ ucsString: UnsafePointer<HGUCSChar>) -> [HGUCSChar] {
   var newUcsString = [HGUCSChar]()
   var skipped = 0
-  while ucsString[skipped + newUcsString.count] != UInt32(0) {
+  // libhangul의 내부 버퍼 크기는 64로 고정되어 있으므로 그 범위 안에서만 읽는다.
+  for _ in 0..<64 {
     let index = skipped + newUcsString.count
+    let currentChar = ucsString[index]
+    // null terminator를 만나면 종료한다.
+    if currentChar == UInt32(0) {
+      break
+    }
     let newChr: HGUCSChar
-    if let chr = table[ucsString[index]] {
+    if let chr = table[currentChar] {
       newChr = chr
     } else {
-      newChr = ucsString[index]
+      newChr = currentChar
     }
     if newChr == choFiller || newChr == jungFiller {
       skipped += 1
@@ -52,9 +58,14 @@ func convertUnicode(_ ucsString: UnsafePointer<HGUCSChar>) -> [HGUCSChar] {
 }
 
 func representableString(ucsString: UnsafePointer<HGUCSChar>) -> String {
+  // 빈 문자열이면 두 번째 문자를 읽지 않고 즉시 반환한다.
+  let firstChar = ucsString[0]
+  guard firstChar != UInt32(0) else {
+    return ""
+  }
+  let secondChar = ucsString[1]
   let isCombinating =
-    !HGCharacterIsChoseong(ucsString[0]) || ucsString[0] == choFiller
-    || ucsString[1] == jungFiller
+    !HGCharacterIsChoseong(firstChar) || firstChar == choFiller || secondChar == jungFiller
   if isCombinating {
     return NSString(ucsString: convertUnicode(ucsString)) as String
   }


### PR DESCRIPTION
## 요약

`origin/working` 브랜치의 `fix crash` 커밋(0360ef9)에서 실제 가치 있는 **libhangul 버퍼 안전성 방어**만 현재 포맷/상수명에 맞춰 가져옵니다.

libhangul은 고정 64칸 버퍼(`commit_string[64]` 등)를 반환하는데, 두 함수가 이 버퍼를 종료 문자에만 의존해 읽고 있어 방어적으로 상한을 둡니다.

## 수정

- **`convertUnicode`**: 종료 문자를 만날 때까지 무한정 읽던 `while` 루프를 고정 64칸 범위 `for _ in 0..<64`로 제한. 종료 문자 없이 꽉 찬 버퍼에서 `ucsString[64]` 범위 밖 읽기를 방지합니다.
- **`representableString`**: 첫 문자가 `0`(빈 문자열)이면 두 번째 문자를 읽지 않고 즉시 `""`를 반환합니다.

## 검증

- `xcodebuild -scheme OSX test` → **44 tests, 0 failures**
- `swift format lint --strict` 통과

## 참고

- 원본 `fix crash` 커밋에 함께 있던 `recentCommitString.last!` 가드는 바로 위 `if recentCommitString.isEmpty` else 분기라 도달 불가하여 제외했습니다.
- 같은 파일을 다루는 #934(force-unwrap 방어)와는 서로 다른 라인이라 충돌하지 않습니다.